### PR TITLE
Swedish translation fix

### DIFF
--- a/Common/src/main/cpp/curve/svjugglucotext.cpp
+++ b/Common/src/main/cpp/curve/svjugglucotext.cpp
@@ -48,7 +48,7 @@ jugglucotext svtext {
 	.middle="Mitten",
 #endif
 	.history="Historik",
-  //	.historyinfo="Var 15:de minut.\nSensorn har minne för de 8 senaste timmarna.\nSkanning överför dem till detta program.\nSensor: ", 
+  //	.historyinfo="Var 15:de minut.\nSensorn har minne för de 8 senaste timmarna.\nSkanning överför dem till detta program.\nSensor: ",
   //	.history3info="Var 5:e minut.\nSensorn har minne för 14 dagar.\nÖverförs via Bluetooth till detta program.\nSensor: ",
 	.sensorstarted= "Startad:",
 	.lastscanned="Senast skannad:",
@@ -85,7 +85,7 @@ jugglucotext svtext {
 		"Export",
 		"Spegling",
 		"Värde",
-		"Lista", 
+		"Lista",
 		"Statistik",
 		"Tal",
 		"Flytande     "
@@ -148,10 +148,10 @@ jugglucotext svtext {
   "Fel! Kontrollera konto-id",
 	"Ange samma konto som används för att aktivera sensorn i Inställningar->Libreview"},
 .libre3scansuccess= {
-  "FreeStyle Libre 3 sensor", 
+  "FreeStyle Libre 3 sensor",
 	"Glukosvärden kommer nu att tas emot av Juggluco"},
 .unknownNFC={
-  "Okänt NFC-skanningfel", 
+  "Okänt NFC-skanningfel",
 	"Försök igen"},
 .nolibre3={
   "FreeStyle Libre 3 sensor",

--- a/Common/src/main/res/values-sv/strings.xml
+++ b/Common/src/main/res/values-sv/strings.xml
@@ -16,9 +16,9 @@
   <string name="ongoing_description">Pågående program</string>
   <string name="scan_permission">Behörigheter</string>
   <string name="scanname">Skanna</string>
-  <string name="scansname">Skanningar</string>
+  <string name="scansname">Skannade</string>
   <string name="historyname">Historiska</string>
-  <string name="streamname">Strömmande</string>
+  <string name="streamname">Strömmade</string>
   <string name="resetname">Återställ</string>
   <string name="helpname">Hjälp</string>
   <string name="searchtopast">Sök tidiagre</string>


### PR DESCRIPTION
Changed some strings as there was an 11 byte length limitation.

Changed the tense of some words to get a shorter text for watch UI.

  Common/src/main/cpp/curve/svjugglucotext.cpp
  Common/src/main/res/values-sv/strings.xml