### PR TITLE
Reliability: foreground-service lifecycle on Android 14/15 (Samsung One UI)

### DIFF
--- a/Common/src/main/AndroidManifest.xml
+++ b/Common/src/main/AndroidManifest.xml
@@ -74,7 +74,6 @@
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
         android:localeConfig="@xml/locales_config"
-        android:persistent="true"
         android:usesCleartextTraffic="true"
         android:networkSecurityConfig="@xml/network_security_config"
         android:pageSizeCompat="enabled"

--- a/Common/src/main/java/tk/glucodata/Applic.java
+++ b/Common/src/main/java/tk/glucodata/Applic.java
@@ -752,21 +752,25 @@ static void doglucose(String SerialNumber, int mgdl, float gl, float rate, int a
 
     var wakelock=    usewakelock?(((PowerManager) app.getSystemService(POWER_SERVICE)).newWakeLock(PowerManager.PARTIAL_WAKE_LOCK, "Juggluco::Applic")):null;
     if(wakelock!=null)
-        wakelock.acquire();
-    if(!wasblueoff) {
-        Applic.dontusebluetooth();
+        wakelock.acquire(10_000L);
+    try {
+        if(!wasblueoff) {
+            Applic.dontusebluetooth();
+            }
+        SuperGattCallback.dowithglucose( SerialNumber,  mgdl, gl,rate,  alarm,  timmsec,sensorstartmsec,Notify.glucosetimeout,sensorgen);
+        if(!isWearable) {
+                if(sensorptr!=0L) {
+                    {if(doLog) {Log.i(LOG_ID,"sensorptr="+format("%x",sensorptr));};};
+                    if(Build.VERSION.SDK_INT >= 28) {
+                        HealthConnection.Companion.writeAll(sensorptr,SerialNumber);
+                        }
+                   }
+            }
         }
-    SuperGattCallback.dowithglucose( SerialNumber,  mgdl, gl,rate,  alarm,  timmsec,sensorstartmsec,Notify.glucosetimeout,sensorgen);
-    if(!isWearable) {
-            if(sensorptr!=0L) {
-                {if(doLog) {Log.i(LOG_ID,"sensorptr="+format("%x",sensorptr));};};
-                if(Build.VERSION.SDK_INT >= 28) {
-                    HealthConnection.Companion.writeAll(sensorptr,SerialNumber);
-                    }
-               }
+    finally {
+        if(wakelock!=null && wakelock.isHeld())
+            wakelock.release();
         }
-    if(wakelock!=null)
-        wakelock.release();
     }
 @Keep
 static boolean updateDevices() { //Rename to reset

--- a/Common/src/main/java/tk/glucodata/Notify.java
+++ b/Common/src/main/java/tk/glucodata/Notify.java
@@ -1041,8 +1041,18 @@ private void novalue() {
     }
 public void foregroundno(Service service) {
     Notification not=getforgroundnotification();
-    service.startForeground(glucosenotificationid, not);
-    {if(doLog) {Log.i(LOG_ID,"startforeground");};};
+    try {
+        service.startForeground(glucosenotificationid, not);
+        {if(doLog) {Log.i(LOG_ID,"startforeground");};};
+        }
+    catch(Throwable e) {
+        // API 34+: a connectedDevice foreground service requires the BLUETOOTH_CONNECT/SCAN
+        // runtime permission. If it was revoked (e.g. One UI auto-reset of unused-app perms),
+        // startForeground throws. Surface it so the user can re-grant, instead of letting it
+        // bubble up to keeprunning's catch and silently stopSelf() with no clue.
+        Log.stack(LOG_ID,"startForeground",e);
+        Applic.Toaster(app.getString(R.string.turn_on_nearby_devices_permission));
+        }
     }
 static public void foregroundnot(Service service) {
 //    Application app=service.getApplication();

--- a/Common/src/main/java/tk/glucodata/keeprunning.java
+++ b/Common/src/main/java/tk/glucodata/keeprunning.java
@@ -27,6 +27,8 @@ import android.content.Intent;
 import android.os.IBinder;
 import android.os.PowerManager;
 
+import androidx.core.content.ContextCompat;
+
 import static tk.glucodata.Applic.isWearable;
 import static tk.glucodata.Log.doLog;
 import static tk.glucodata.Log.stack;
@@ -85,6 +87,7 @@ static PowerManager.WakeLock wakeLock =null;
              }
              theservice=this;
              Notify.foregroundnot(this);
+             acquireWakelock();
              return Service.START_STICKY;
             } 
         catch(Throwable e) {
@@ -104,7 +107,11 @@ static boolean start(Context context) {
        if(!started||theservice==null) {
           {if(doLog) {Log.i(LOG_ID,"start keeprunning");};};
           Intent i = new Intent(context, keeprunning.class);
-           context.startService(i);
+           // targetSdk 35: a background-initiated startService() (boot/exact-alarm revive)
+           // throws and the catch below swallows it, so the service silently never starts.
+           // startForegroundService() is legal from those exempt entry points; onStartCommand
+           // then calls startForeground() within the allowed window.
+           ContextCompat.startForegroundService(context, i);
            if(theservice!=null)
                Notify.foregroundnot(theservice);
            return true;
@@ -115,10 +122,38 @@ static boolean start(Context context) {
       }
    return false;
    }
+// Lifetime PARTIAL_WAKE_LOCK, gated on the existing user "wakelock" preference, so the
+// streaming service keeps the CPU available for GATT callbacks while it runs. Reference
+// counting is off so a stray double-acquire/release cannot underflow.
+static void acquireWakelock() {
+   if(!Natives.getwakelock())
+      return;
+   try {
+      if(wakeLock==null) {
+         PowerManager powerManager=(PowerManager)Applic.app.getSystemService(Context.POWER_SERVICE);
+         wakeLock=powerManager.newWakeLock(PowerManager.PARTIAL_WAKE_LOCK, "Juggluco::keeprunning");
+         wakeLock.setReferenceCounted(false);
+         }
+      if(!wakeLock.isHeld())
+         wakeLock.acquire();
+      }
+   catch(Throwable e) {
+      stack(LOG_ID,e);
+      }
+   }
+static void releaseWakelock() {
+   try {
+      if(wakeLock!=null && wakeLock.isHeld())
+         wakeLock.release();
+      }
+   catch(Throwable e) {
+      stack(LOG_ID,e);
+      }
+   }
 void stopper() {
    stopForeground(true);
    stopSelf();
-//   turnoffwakelock();
+   releaseWakelock();
    {if(doLog) {Log.i(LOG_ID,"Stopped");};};
    }
 static void stop() {


### PR DESCRIPTION
Fixes the FreeStyle Libre streaming foreground-service silently failing to (re)start in the background on modern Android — most visible on Samsung One UI, which suspends backgrounded apps aggressively.

### Changes
- **`keeprunning.start()`** — use `ContextCompat.startForegroundService()` instead of `startService()`. On `targetSdk 35` a background-initiated `startService()` throws, and the surrounding `catch` swallows it, so after a reboot or process-kill the service never came back until the app was reopened.
- **`Notify.foregroundno()`** — wrap `startForeground()` so a revoked Nearby-devices permission surfaces a prompt instead of cascading into a silent `stopSelf()`.
- **`keeprunning`** — restore the (preference-gated) lifetime `PARTIAL_WAKE_LOCK`.
- **`Applic.doglucose()`** — bound the wakelock acquire with a timeout and release it in `finally`.
- **manifest** — remove the inert `android:persistent` (honored only for system-signed apps).

### Testing
- Compiles cleanly; the diff introduces **zero** new compile errors vs. base (identical `javac` output with/without the change) on a `mobile…Debug` variant.
- **Not device-tested by the author** — the reboot / out-of-range recovery behaviour needs verification on a real phone. Opened as **draft** for review.

Draft for maintainer review; happy to split or adjust.
