### PR TITLE
Reliability: GATT-client leak, scan-throttle race & receiver-leak hardening

### DIFF
--- a/Common/src/main/java/tk/glucodata/Libre2GattCallback.java
+++ b/Common/src/main/java/tk/glucodata/Libre2GattCallback.java
@@ -156,6 +156,9 @@ private PendingIntent onalarm=null;
                connected=true;
 				if(!bluetoothGatt.discoverServices()) {
 					Log.e(LOG_ID,"bluetoothGatt.discoverServices()  failed");
+					// Don't sit idle in CONNECTED until the ~6-min loss watchdog: force a clean
+					// disconnect so the existing reconnect path re-drives a fresh connection.
+					bluetoothGatt.disconnect();
 					}
 				constatchange[0] = tim;
 				setpriority(bluetoothGatt);

--- a/Common/src/main/java/tk/glucodata/SensorBluetooth.java
+++ b/Common/src/main/java/tk/glucodata/SensorBluetooth.java
@@ -276,6 +276,9 @@ private static final  boolean alwaysfilter=true;
     Scanner21() {
         ScanSettings.Builder builder = new ScanSettings.Builder();
         builder.setReportDelay(0);
+        // Low-power (the default) delivers scan results slowly with the screen off; the reconnect
+        // scan is a short-lived fallback, so low-latency rediscovers the sensor much faster.
+        builder.setScanMode(ScanSettings.SCAN_MODE_LOW_LATENCY);
         mScanSettings = builder.build();
         {if(doLog) {Log.i(LOG_ID,"Scanner21");};};
         }
@@ -467,13 +470,21 @@ static  final ArrayDeque<Long> scanStarts = new ArrayDeque<>();
 
 
 static long delayUntilScanAllowed() {
-    long now = SystemClock.elapsedRealtime();
-    while(!scanStarts.isEmpty() && (now - scanStarts.peekFirst()) >= WINDOW_MS) {
-        scanStarts.removeFirst();
-    }
-    if (scanStarts.size() < MAX_SCAN_STARTS) return 0L;
-
-    return WINDOW_MS - (now - scanStarts.peekFirst());
+    // Prune the sliding window, check the Samsung ~5-starts/31s budget, and record this start
+    // atomically under the scanStarts monitor. Without the lock the scheduler-thread prune/peek
+    // races the main-thread clear() in the BT-state receiver, mis-counting the window and either
+    // over-delaying reconnect or tripping Samsung's silent scan throttle (~30s of no results).
+    synchronized(scanStarts) {
+        long now = SystemClock.elapsedRealtime();
+        while(!scanStarts.isEmpty() && (now - scanStarts.peekFirst()) >= WINDOW_MS) {
+            scanStarts.removeFirst();
+        }
+        if (scanStarts.size() < MAX_SCAN_STARTS) {
+            scanStarts.addLast(now);
+            return 0L;
+            }
+        return WINDOW_MS - (now - scanStarts.peekFirst());
+        }
 }
 
 private void startScanGuarded() {
@@ -488,9 +499,7 @@ private void startScanGuarded() {
             }
         return;
         }
-     final  long elapsed= SystemClock.elapsedRealtime();
-    scanStarts.addLast(elapsed);
-
+    // This scan start was already recorded atomically inside delayUntilScanAllowed() above.
     scanRunnable.run();
    // bluetoothLeScanner.startScan(scanCallback);
    }
@@ -996,7 +1005,7 @@ private void addBluetoothStateReceiver() {
                         }
                     cb.close();
                     }
-                 scanStarts.clear();
+                 synchronized(scanStarts) { scanStarts.clear(); }
                 if(keepBluetooth) mBluetoothAdapter.enable();
                 } 
             else if (intExtra == BluetoothAdapter.STATE_ON) {
@@ -1099,11 +1108,16 @@ private void addReceivers() {
 private void removeReceivers() {
    removeBluetoothStateReceiver();
    removeBondStateReceiver() ;
-   if(Build.VERSION.SDK_INT <26)
-        removePairingRequestReceiver();
+   // addReceivers() registers the pairing receiver on every API level, so always unregister it.
+   // The old SDK<26 guard leaked one registration per teardown on API >= 26 (the S24 FE).
+   removePairingRequestReceiver();
     }
 private BroadcastReceiver bondStateReceiver =null;
 private void addBondStateReceiver() {
+    // Idempotent: addReceivers() can run more than once; without this each call leaked a
+    // BroadcastReceiver registration (removeBondStateReceiver can only drop the latest one).
+    if(bondStateReceiver!=null)
+        removeBondStateReceiver();
     bondStateReceiver=new BroadcastReceiver() {
         @Override
         public void onReceive(Context context, Intent intent) {
@@ -1158,7 +1172,12 @@ private void addBondStateReceiver() {
         {if(doLog) {Log.i(LOG_ID,"Bond Broadcast: no sensor matches address "+address);};};
         }
     };
-    Applic.app.registerReceiver(bondStateReceiver, new IntentFilter(ACTION_BOND_STATE_CHANGED));
+    try {
+        Applic.app.registerReceiver(bondStateReceiver, new IntentFilter(ACTION_BOND_STATE_CHANGED));
+        }
+    catch(Throwable th) {
+        Log.stack(LOG_ID, "addBondStateReceiver", th);
+        }
     }
 
 private void removeBondStateReceiver() {

--- a/Common/src/main/java/tk/glucodata/SuperGattCallback.java
+++ b/Common/src/main/java/tk/glucodata/SuperGattCallback.java
@@ -95,7 +95,7 @@ public static boolean doGadgetbridge=false;
     long dataptr = 0L;
     public BluetoothDevice mActiveBluetoothDevice;
     long foundtime = 0L;
-    protected BluetoothGatt mBluetoothGatt;
+    protected volatile BluetoothGatt mBluetoothGatt;
     boolean superseded=false;
     public final int sensorgen;
     int readrssi=9999;
@@ -121,7 +121,10 @@ public void disconnect() {
     }
 public boolean reconnect(long now) {
     final var old=now-showtime+20;
-    if(charcha[1]<old&&connectTime<(now-60*1000))  {
+    // Gate on the most recent BLE frame activity (last good reading OR last failed decode),
+    // not only charcha[1]: in a healthy stream charcha[1] never advances, so testing it alone
+    // made this branch fire on a spurious/late loss alarm and drop a live connection.
+    if(Math.max(charcha[0],charcha[1])<old&&connectTime<(now-60*1000))  {
         try {
             if(doLog) {Log.i(LOG_ID,"reconnect "+SerialNumber);};
             constatstatusstr = "Loss of signal";
@@ -550,10 +553,16 @@ public void searchforDeviceAddress() {
                 return;
                 }
         
+            // Serialize the null-check + connectGatt + field assignment. Connect Runnables can be
+            // posted from several threads (BLE scan binder thread, GATT-callback thread, loss-of-signal
+            // alarm); without this two of them could both pass the guard and the second connectGatt
+            // would overwrite mBluetoothGatt without close()ing the first -> a leaked GATT client
+            // interface each time, eventually exhausting the ~30-client limit (permanent status 133).
+            synchronized(cb) {
             if (cb.mBluetoothGatt != null) {
                 {if(doLog) {Log.d(LOG_ID, SerialNumber + " cb.mBluetoothGatt!=null");};};
                 return;
-                } 
+                }
             var devname=device.getName();
             if(devname!=null)
                 mDeviceName=devname;
@@ -588,6 +597,7 @@ public void searchforDeviceAddress() {
                     Log.stack(LOG_ID, SerialNumber +" "+ "connectGatt", e);
 
                     }
+            }
         };
     }
 


### PR DESCRIPTION
Hardens the BLE connection path against the slow-onset "sensor won't reconnect until I force-stop the app" failure, plus a few robustness gaps (most visible on Samsung One UI).

### Changes
- **`SuperGattCallback`** — `mBluetoothGatt` is now `volatile`, and the null-check + `connectGatt` + assignment run inside one `synchronized(cb)` block. Connect Runnables are posted from several threads (scan binder, GATT callback, loss-of-signal alarm); two could both pass the guard and the second `connectGatt` overwrote `mBluetoothGatt` without `close()`ing the first — leaking a GATT client each time until the ~30-client limit (permanent status 133).
- **`SuperGattCallback.reconnect()`** — gate freshness on `max(charcha[0], charcha[1])` so a spurious/late loss alarm can't drop a live stream (`charcha[1]` never advances during healthy streaming).
- **`Libre2GattCallback`** — when `discoverServices()` returns `false`, `disconnect()` so the reconnect path re-drives, instead of idling in CONNECTED until the ~6-min watchdog.
- **`SensorBluetooth`** — make the Samsung ~5-scans/31 s throttle bookkeeping atomic (prune+check+record under one monitor; `clear()` takes the same lock); make `addBondStateReceiver` idempotent; always unregister the pairing receiver (the `SDK<26` guard leaked it on API ≥ 34); `SCAN_MODE_LOW_LATENCY` on the reconnect scan.

### Testing
- Compiles cleanly; the diff introduces **zero** new compile errors vs. base on a `mobile…Debug` variant.
- **Not device-tested by the author** — the leak/reconnect behaviour needs verification on a real phone over time. Opened as **draft**.
