### PR TITLE
feat(mobile): widgets, lock-screen card, alarm activity and snooze

### DIFF
--- a/Common/src/main/cpp/curve/javacurve.cpp
+++ b/Common/src/main/cpp/curve/javacurve.cpp
@@ -935,6 +935,7 @@ extern "C" JNIEXPORT void JNICALL fromjava(endstats) (JNIEnv *env, jclass clazz)
 	appcurve.begrenstijd() ;
 	}
 #include "net/watchserver/Getopts.hpp"
+#include "nanovg_rt.h"
 extern int getminutes(time_t tim);
 extern "C" JNIEXPORT jlong JNICALL fromjava(percentileEndtime) (JNIEnv *env, jclass clazz,jint days) {
  const uint32_t  endtime=appcurve.starttime+appcurve.duration;
@@ -945,6 +946,102 @@ extern "C" JNIEXPORT jlong JNICALL fromjava(percentileEndtime) (JNIEnv *env, jcl
  opts.start=endday-days*daysecs;
  return endtime;
  }
+
+/**
+ * Render an off-screen glucose curve for a home-screen widget using the
+ * NanoVG-RT (software raytracer) backend.
+ *
+ * Parameters (from Java):
+ *   widthPx    - pixel width of the target ImageView
+ *   heightPx   - pixel height of the target ImageView
+ *   durationSecs - how many seconds of history to show (e.g. 3*3600 = 3h)
+ *
+ * Returns a jintArray of ARGB pixels (widthPx * heightPx elements) ready for
+ * Bitmap.createBitmap(), or null if no data / not initialised.
+ *
+ * The returned array uses ARGB_8888 layout: each int = (A<<24)|(R<<16)|(G<<8)|B.
+ * NanoVG-RT writes RGBA bytes; we swap R and B to match Android's ARGB_8888.
+ */
+extern std::span<char> getCurveImage(int startpos, Getopts &opts);
+extern "C" JNIEXPORT jintArray JNICALL fromjava(getWidgetGraphBitmap)(
+        JNIEnv *env, jclass clazz,
+        jint widthPx, jint heightPx, jint durationSecs) {
+    if (!sensors || widthPx <= 0 || heightPx <= 0 || durationSecs <= 0)
+        return nullptr;
+
+    const uint32_t endtime = (uint32_t)time(nullptr);
+    Getopts opts;
+    opts.end   = endtime;
+    opts.start = endtime - (uint32_t)durationSecs;
+    opts.width  = widthPx;
+    opts.height = heightPx;
+    opts.darkmode = appcurve.invertcolors;
+    // Use the same display mode as the live graph
+    opts.streammode    = appcurve.showstream  != 0;
+    opts.scansmode     = appcurve.showscans   != 0;
+    opts.historymode   = appcurve.showhistories != 0;
+    opts.calibratedmode = appcurve.showcalibratedstream != 0;
+    opts.allvaluesmode  = appcurve.allvalues;
+
+    // getCurveImage encodes to PNG with a startpos prefix; we don't need the
+    // PNG — we only need raw pixels.  Use the RT path directly instead.
+    const double multiply = (double)heightPx / 800.0;
+    JCurve curveimage(settings->data()->unit);
+    curveimage.showstream  = appcurve.showstream;
+    curveimage.showscans   = appcurve.showscans;
+    curveimage.showhistories = appcurve.showhistories;
+    curveimage.showcalibratedstream = appcurve.showcalibratedstream;
+    curveimage.allvalues   = appcurve.allvalues;
+    curveimage.invertcolorsset(appcurve.invertcolors);
+    curveimage.dheight = heightPx;
+    curveimage.dwidth  = widthPx;
+    curveimage.setfontsize(
+        38.5 * multiply, 44.0 * multiply,
+        2.8  * multiply, 250.0 * multiply);
+
+    auto vg = nvgCreateRT(0, widthPx, heightPx);
+    if (!vg) return nullptr;
+    curveimage.initfont(vg);
+
+    const NVGcolor bgcol = *curveimage.getwhite();
+    nvgClearBackgroundRT(vg, bgcol.r, bgcol.g, bgcol.b, bgcol.a);
+    curveimage.startstepNVG(vg, widthPx, heightPx);
+
+    curveimage.starttime = opts.start;
+    curveimage.duration  = (uint32_t)durationSecs;
+    curveimage.displaycurve(vg, endtime);
+    nvgEndFrame(vg);
+
+    const unsigned char *rgba = nvgReadPixelsRT(vg);
+    if (!rgba) {
+        nvgDeleteRT(vg);
+        return nullptr;
+    }
+
+    // Convert RGBA8 → Android ARGB_8888 (swap R and B)
+    const int npixels = widthPx * heightPx;
+    jintArray result = env->NewIntArray(npixels);
+    if (!result) {
+        nvgDeleteRT(vg);
+        return nullptr;
+    }
+    jint *pixels = env->GetIntArrayElements(result, nullptr);
+    if (!pixels) {
+        nvgDeleteRT(vg);
+        return nullptr;
+    }
+    for (int i = 0; i < npixels; i++) {
+        const int base = i * 4;
+        const unsigned int r = rgba[base + 0];
+        const unsigned int g = rgba[base + 1];
+        const unsigned int b = rgba[base + 2];
+        const unsigned int a = rgba[base + 3];
+        pixels[i] = (int)((a << 24) | (r << 16) | (g << 8) | b);
+    }
+    env->ReleaseIntArrayElements(result, pixels, 0);
+    nvgDeleteRT(vg);
+    return result;
+}
 
 #endif
 extern "C" JNIEXPORT void  JNICALL   fromjava(setInvertColors)(JNIEnv *env, jclass cl,jboolean val) {

--- a/Common/src/main/java/tk/glucodata/Natives.java
+++ b/Common/src/main/java/tk/glucodata/Natives.java
@@ -252,6 +252,17 @@ public static native void sethaslibrary(boolean val);
 public static native boolean gethaslibrary( );
 public static native int getScreenOrientation( );
 public static native void setScreenOrientation(int val);
+
+/**
+ * Render an off-screen glucose curve using the NanoVG-RT software backend.
+ * Returns a widthPx×heightPx ARGB_8888 int[] ready for Bitmap.createBitmap(),
+ * or null when no sensor data is available or the native library is not loaded.
+ *
+ * @param widthPx      pixel width of the destination ImageView
+ * @param heightPx     pixel height of the destination ImageView
+ * @param durationSecs seconds of history to show (e.g. 3*3600 for 3 hours)
+ */
+public static native int[] getWidgetGraphBitmap(int widthPx, int heightPx, int durationSecs);
 public static native boolean gethasgarmin( );
 public static native void sethasgarmin(boolean val);
 public static native void setusebluetooth(boolean val);

--- a/Common/src/main/java/tk/glucodata/Notify.java
+++ b/Common/src/main/java/tk/glucodata/Notify.java
@@ -27,6 +27,8 @@ import static android.content.Context.NOTIFICATION_SERVICE;
 import static android.content.Context.VIBRATOR_SERVICE;
 import static android.graphics.Color.BLACK;
 import static android.graphics.Color.WHITE;
+import android.graphics.Bitmap;
+import android.view.View;
 import static android.media.AudioAttributes.USAGE_NOTIFICATION;
 import static android.media.AudioAttributes.USAGE_ASSISTANCE_SONIFICATION;
 import static java.lang.String.format;
@@ -580,6 +582,11 @@ static void stopGlucoseAlarm() {
                 else
                     doTurnFocusoff();
 
+                // Cancel the separate alarm notification (posted on glucosealarmid to
+                // allow setFullScreenIntent to fire — see arrowplacelargenotification).
+                if (!isWearable && glucosealarm) {
+                    notificationManager.cancel(glucosealarmid);
+                }
                 if(glucosealarm) overwriteglucose(kind);
                 setisalarm(false);
 
@@ -807,67 +814,189 @@ private void  makeseparatenotification(float glvalue,String message,notGlucose g
         }
     }
 static public boolean alertseparate=false;
-    private Notification  makearrownotification(int kind,float glvalue,String message,notGlucose glucose,String type,boolean once) {
 
-        var intent =mkpending();
-        var GluNotBuilder=mkbuilderintent(type,intent);
-        if(!alertseparate) {
-            GluNotBuilder.setDeleteIntent(DeleteReceiver.getDeleteIntent());
-            }
-        {if(doLog) {Log.i(LOG_ID,"makearrownotification setOnlyAlertOnce("+once+") "+glucose.value);};};
-
-        //var draw= GlucoseDraw.getgludraw(glvalue);
-
-          setIcon(GluNotBuilder,glvalue,glucose.sensorgen2);
-//        GluNotBuilder.setSmallIcon(draw). 
-        GluNotBuilder.setContentTitle(message).setOnlyAlertOnce(once);
-
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
-            GluNotBuilder.setVisibility(VISIBILITY_PUBLIC);
-            }
-        final boolean glucosealarm=kind<2||kind>4;
-        if(!isWearable) {
-              if(Build.VERSION.SDK_INT  >= 24) {
-                GluNotBuilder.setStyle(new Notification.DecoratedCustomViewStyle());
-        //    GluNotBuilder.setStyle( new Notification.DecoratedMediaCustomViewStyle());
-            }
-            GluNotBuilder.setShowWhen(true);
-            RemoteViews remoteViews=arrowNotify.arrowremote(kind,glucose,glucosealarm&&!once);
-            if(whiteonblack) {
-                if(Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-                    GluNotBuilder.setColorized(true);
-                    GluNotBuilder.setColor(BLACK);
-                    }
-                else
-                    remoteViews.setInt(arrowandvalue, "setBackgroundColor", BLACK);
-                }
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
-                GluNotBuilder.setCustomContentView(remoteViews);
-            } else
-                GluNotBuilder.setContent(remoteViews);
-            }
-    if(Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-        GluNotBuilder.setTimeoutAfter(glucosetimeout);
-    }
-    if(isWearable) {GluNotBuilder.setAutoCancel(true);}
-    if(once)
-        GluNotBuilder.setPriority(Notification.PRIORITY_DEFAULT);
-    else  {
-    //    GluNotBuilder.setPriority(Notification.PRIORITY_DEFAULT);
-        GluNotBuilder.setPriority(Notification.PRIORITY_HIGH);
-//        GluNotBuilder.setPriority(Notification.PRIORITY_MAX);
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
-            GluNotBuilder.setCategory(Notification.CATEGORY_ALARM);
+    /**
+     * Builds the big (expanded) RemoteViews for an alarm notification:
+     * same arrow+value row as alarm.xml plus a 3-hour graph below.
+     * Snooze action buttons are added by the builder (Notification.Action),
+     * not inside this layout.
+     */
+    private RemoteViews buildAlarmBigView(int kind, notGlucose glucose) {
+        final RemoteViews rv = new RemoteViews(app.getPackageName(), R.layout.alarm_big);
+        // ── Stop-alarm button click intent (same as arrowremote for alarm layout) ──
+        android.content.Intent closeintent = new android.content.Intent(app, NumAlarm.class);
+        closeintent.setAction(RemoteGlucose.stopalarmAction);
+        android.app.PendingIntent closepending = android.app.PendingIntent.getBroadcast(
+                app, stopalarmrequest, closeintent,
+                android.app.PendingIntent.FLAG_UPDATE_CURRENT | penmutable);
+        rv.setOnClickPendingIntent(R.id.stopalarm, closepending);
+        // ── Arrow+value bitmap ──
+        // buildArrowValueBitmap() re-runs the paint path and returns a copy of the
+        // shared canvas bitmap.  We set it directly on alarm_big's arrowandvalue ImageView.
+        if (arrowNotify != null && glucose != null && glucose.value != null) {
+            rv.setImageViewBitmap(R.id.arrowandvalue,
+                    arrowNotify.buildArrowValueBitmap(kind, glucose));
         }
+        // ── Graph ──
+        if (Applic.Nativesloaded) {
+            try {
+                final DisplayMetrics dm = app.getResources().getDisplayMetrics();
+                final int wPx = Math.round(dm.widthPixels * 0.95f);
+                final int hPx = Math.round(100 * dm.density);
+                if (wPx >= 60 && hPx >= 40) {
+                    final int[] pixels = Natives.getWidgetGraphBitmap(wPx, hPx, 3 * 3600);
+                    if (pixels != null) {
+                        final Bitmap graphBmp = Bitmap.createBitmap(pixels, wPx, hPx,
+                                android.graphics.Bitmap.Config.ARGB_8888);
+                        rv.setImageViewBitmap(R.id.alarm_graph, graphBmp);
+                        rv.setViewVisibility(R.id.alarm_graph, View.VISIBLE);
+                    }
+                }
+            } catch (Throwable t) {
+                Log.stack(LOG_ID, "buildAlarmBigView graph", t);
+            }
+        }
+        return rv;
     }
 
-     {if(doLog) {Log.i(LOG_ID,(once?"":"not ")+"only once");};};
+    private Notification  makearrownotification(int kind,float glvalue,String message,notGlucose glucose,String type,boolean once) {
+    
+            // For active alarms on phone, tapping the notification opens AlarmLockScreenActivity
+            // (same screen as the full-screen intent) so the snooze buttons are always accessible.
+            final boolean glucosealarmForContent = (kind<2||kind>4);
+            final var intent = (!isWearable && !once && glucosealarmForContent && AlarmLockScreenActivity.isEnabled())
+                    ? mkAlarmLockScreenPending(kind)
+                    : mkpending();
+            var GluNotBuilder=mkbuilderintent(type,intent);
+            if(!alertseparate) {
+                GluNotBuilder.setDeleteIntent(DeleteReceiver.getDeleteIntent());
+                }
+            {if(doLog) {Log.i(LOG_ID,"makearrownotification setOnlyAlertOnce("+once+") "+glucose.value);};};
+    
+            //var draw= GlucoseDraw.getgludraw(glvalue);
+    
+              setIcon(GluNotBuilder,glvalue,glucose.sensorgen2);
+    //        GluNotBuilder.setSmallIcon(draw).
+            GluNotBuilder.setContentTitle(message).setOnlyAlertOnce(once);
+    
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+                GluNotBuilder.setVisibility(VISIBILITY_PUBLIC);
+                }
+            final boolean glucosealarm=kind<2||kind>4;
+            if(!isWearable) {
+                // Do NOT wrap in DecoratedCustomViewStyle — that strips custom text colours
+                // on the collapsed row and adds unwanted system chrome.
+                GluNotBuilder.setShowWhen(true);
+                RemoteViews remoteViews=arrowNotify.arrowremote(kind,glucose,glucosealarm&&!once);
+                if(whiteonblack) {
+                    if(Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+                        GluNotBuilder.setColorized(true);
+                        GluNotBuilder.setColor(BLACK);
+                        }
+                    else
+                        remoteViews.setInt(arrowandvalue, "setBackgroundColor", BLACK);
+                    }
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+                    GluNotBuilder.setCustomContentView(remoteViews);
+                    // Big (expanded) view: same row + 3-hour graph + snooze actions visible below
+                    if (glucosealarm && !once) {
+                        GluNotBuilder.setCustomBigContentView(
+                                buildAlarmBigView(kind, glucose));
+                    }
+                } else {
+                    GluNotBuilder.setContent(remoteViews);
+                }
+                }
+        if(Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            GluNotBuilder.setTimeoutAfter(glucosetimeout);
+        }
+        if(isWearable) {GluNotBuilder.setAutoCancel(true);}
+        if(once)
+            GluNotBuilder.setPriority(Notification.PRIORITY_DEFAULT);
+        else  {
+            // MAX priority + CATEGORY_ALARM ensures the notification appears as a
+            // heads-up over other notifications and the full-screen intent fires
+            // reliably on the lock screen even when other notifications are present.
+            GluNotBuilder.setPriority(Notification.PRIORITY_MAX);
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+                GluNotBuilder.setCategory(Notification.CATEGORY_ALARM);
+            }
+            // Ongoing flag prevents the user from accidentally swiping the alarm
+            // notification away — they must use the hold-to-dismiss button.
+            if (!isWearable && glucosealarm) {
+                GluNotBuilder.setOngoing(true);
+            }
+            // ── Full-screen lock-screen intent for active alarms (phone only) ──
+            // Guarded by hasFullScreenIntentPermission(): on Android 14+ the user must
+            // explicitly grant USE_FULL_SCREEN_INTENT in Settings.  Without the grant,
+            // Android silently ignores setFullScreenIntent() so we skip it entirely and
+            // fall back to the heads-up notification + action buttons below.
+            if (!isWearable && glucosealarm && AlarmLockScreenActivity.isEnabled()
+                    && AlarmLockScreenActivity.hasFullScreenIntentPermission()) {
+                try {
+                    Intent fsIntent = new Intent(app, AlarmLockScreenActivity.class);
+                    fsIntent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK
+                            | Intent.FLAG_ACTIVITY_CLEAR_TASK
+                            | Intent.FLAG_ACTIVITY_EXCLUDE_FROM_RECENTS
+                            | Intent.FLAG_ACTIVITY_NO_USER_ACTION);
+                    fsIntent.putExtra(AlarmLockScreenActivity.EXTRA_ALARM_KIND, kind);
+                    PendingIntent fsPendingIntent = PendingIntent.getActivity(
+                            app, 900, fsIntent,
+                            PendingIntent.FLAG_IMMUTABLE | PendingIntent.FLAG_UPDATE_CURRENT);
+                    GluNotBuilder.setFullScreenIntent(fsPendingIntent, true);
+                    {if(doLog) {Log.i(LOG_ID, "setFullScreenIntent for alarm kind=" + kind);};};
+                } catch (Throwable t) {
+                    Log.stack(LOG_ID, "setFullScreenIntent", t);
+                }
+            }
+            // ── Stop + Snooze notification actions (phone only, active alarms) ───
+            // These action buttons are visible without expanding the notification and
+            // work even when the full-screen intent cannot fire (e.g. permission not
+            // granted, or user is in a full-screen game that blocks heads-up pop-ups).
+            if (!isWearable && glucosealarm) {
+                try {
+                    // "Stop alarm" — single tap, stops sound immediately
+                    final Intent stopIntent = new Intent(app, NumAlarm.class);
+                    stopIntent.setAction(RemoteGlucose.stopalarmAction);
+                    final PendingIntent stopPi = PendingIntent.getBroadcast(
+                            app, stopalarmrequest,
+                            stopIntent,
+                            PendingIntent.FLAG_UPDATE_CURRENT | penmutable);
+                    GluNotBuilder.addAction(new Notification.Action.Builder(
+                            android.R.drawable.ic_delete,
+                            app.getString(R.string.notif_stop_alarm),
+                            stopPi).build());
 
-     Notification notif= GluNotBuilder.build();
-    notif.when= glucose.time;
-     return notif;
+                    // Snooze duration buttons
+                    final java.util.List<Long> snoozeDurations = AlarmSnooze.getSnoozeButtons();
+                    if (!snoozeDurations.isEmpty()) {
+                        GluNotBuilder.setSubText(app.getString(R.string.notif_snooze_label));
+                    }
+                    // request codes 910..912 — well away from other PendingIntents
+                    for (int si = 0; si < snoozeDurations.size(); si++) {
+                        final long mins = snoozeDurations.get(si);
+                        final PendingIntent snoozePi = SnoozeReceiver.pendingSnooze(mins, 910 + si);
+                        if (snoozePi != null) {
+                            final Notification.Action action = new Notification.Action.Builder(
+                                    android.R.drawable.ic_lock_silent_mode_off,
+                                    app.getString(R.string.notif_snooze_min, mins),
+                                    snoozePi).build();
+                            GluNotBuilder.addAction(action);
+                        }
+                    }
+                } catch (Throwable t) {
+                    Log.stack(LOG_ID, "addAlarmActions", t);
+                }
+            }
+        }
 
-    }
+         {if(doLog) {Log.i(LOG_ID,(once?"":"not ")+"only once");};};
+    
+         Notification notif= GluNotBuilder.build();
+        notif.when= glucose.time;
+         return notif;
+    
+        }
 @SuppressWarnings({"deprecation"})
 
 static public PendingIntent mkpendingall(Context context, int requestCode) {
@@ -888,6 +1017,20 @@ static public PendingIntent mkpendingall(Context context, int requestCode) {
 static public PendingIntent mkpending() {
     return mkpendingall(Applic.app,1001);
     }
+
+/** PendingIntent that opens AlarmLockScreenActivity — used as the notification contentIntent
+ *  so tapping the alarm notification always shows the snooze UI, not just the main app. */
+static private PendingIntent mkAlarmLockScreenPending(int kind) {
+    Intent intent = new Intent(Applic.app, AlarmLockScreenActivity.class);
+    intent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK
+            | Intent.FLAG_ACTIVITY_CLEAR_TASK
+            | Intent.FLAG_ACTIVITY_EXCLUDE_FROM_RECENTS
+            | Intent.FLAG_ACTIVITY_NO_USER_ACTION);
+    intent.putExtra(AlarmLockScreenActivity.EXTRA_ALARM_KIND, kind);
+    return PendingIntent.getActivity(Applic.app, 901, intent,
+            PendingIntent.FLAG_IMMUTABLE | PendingIntent.FLAG_UPDATE_CURRENT);
+    }
+
 
 private Notification.Builder   mkbuilderintent(String type,PendingIntent notifyPendingIntent) {
     Notification.Builder  GluNotBuilder;
@@ -1076,8 +1219,17 @@ static void test2() {
 
 private  void  arrowplacelargenotification(int kind,float glvalue,String message,notGlucose glucose,String type,boolean once) {
         hasvalue=true;
-    fornotify(makearrownotification(kind,glvalue,message,glucose,type,once));
-
+        final Notification notif = makearrownotification(kind,glvalue,message,glucose,type,once);
+        if (!once && !isWearable) {
+            // Active alarm notification: post on glucosealarmid via notificationManager.notify()
+            // so that setFullScreenIntent() is honoured by the OS.
+            // Android silently ignores setFullScreenIntent on foreground-service notifications
+            // (the startForeground() path in fornotify()), so we must bypass it here.
+            notificationManager.cancel(glucosealarmid);
+            notificationManager.notify(glucosealarmid, notif);
+        } else {
+            fornotify(notif);
+        }
     }
  public void  lossofsensornotification(int draw,String message,String type,boolean once) {
      {if(doLog) {Log.i(LOG_ID,"notify "+message);};};

--- a/Common/src/main/java/tk/glucodata/RemoteGlucose.java
+++ b/Common/src/main/java/tk/glucodata/RemoteGlucose.java
@@ -33,9 +33,13 @@ import static tk.glucodata.Notify.penmutable;
 import static tk.glucodata.Notify.stopalarmrequest;
 import static tk.glucodata.Notify.unitlabel;
 
+import android.graphics.Color;
+
 import android.annotation.SuppressLint;
 import android.app.PendingIntent;
+import android.content.Context;
 import android.content.Intent;
+import android.content.SharedPreferences;
 import android.content.res.TypedArray;
 import android.graphics.Bitmap;
 import android.graphics.Canvas;
@@ -54,8 +58,72 @@ import static tk.glucodata.R.id.arrowandvalue;
 import java.text.DateFormat;
 import java.util.Date;
 
-class RemoteGlucose {
+public class RemoteGlucose {
 final private static String LOG_ID="RemoteGlucose";
+
+private static final String PREFS = "juggluco_dev";
+
+/**
+ * Returns a colour for the glucose value text, mirroring GlucoDataHandler's
+ * four-tier alarm colour scheme:
+ *
+ *   GREEN  — within the in-range target window (targetlow .. targethigh)
+ *   YELLOW — outside the target window but within the alarm range
+ *            (alarmlow .. targetlow  OR  targethigh .. alarmhigh)
+ *   RED    — at or beyond the alarm boundary (≤ alarmlow  OR  ≥ alarmhigh)
+ *            also covers very-low / very-high thresholds
+ *
+ * Falls back:
+ *   • if target thresholds are zero/unset, treat alarm thresholds as the
+ *     target (green zone = alarmlow..alarmhigh, no yellow band).
+ *   • if alarm thresholds are also unset, return WHITE.
+ *
+ * Unit safety: all native threshold values are already in the user's chosen
+ * display unit (the C layer converts before storing).
+ */
+static int glucoseRangeColor(float glValue) {
+    final float alarmLow  = Natives.alarmlow();
+    final float alarmHigh = Natives.alarmhigh();
+    // No alarm thresholds configured — can't colour
+    if (alarmLow <= 0f && alarmHigh <= 0f) return WHITE;
+
+    // RED: at or beyond alarm boundary
+    if (alarmLow  > 0f && glValue <= alarmLow)  return Color.RED;
+    if (alarmHigh > 0f && glValue >= alarmHigh) return Color.RED;
+
+    // Target (inner) range — use if configured, else fall back to alarm range
+    float targetLow  = Natives.targetlow();
+    float targetHigh = Natives.targethigh();
+    if (targetLow  <= 0f) targetLow  = alarmLow;
+    if (targetHigh <= 0f) targetHigh = alarmHigh;
+
+    // GREEN: within target range
+    if (glValue > targetLow && glValue < targetHigh) return Color.GREEN;
+
+    // YELLOW: between target and alarm boundary (warn zone)
+    return Color.YELLOW;
+}
+
+// ── Widget background alpha ───────────────────────────────────────────────
+private static final String KEY_BG_ALPHA = "widget_bg_alpha";
+
+/**
+ * Returns the stored widget background alpha (0-255). 0 = fully transparent
+ * (default, same as before). Any non-zero value adds a semi-transparent black
+ * background behind the widget content.
+ */
+public static int getWidgetBgAlpha() {
+    return Applic.app
+            .getSharedPreferences(PREFS, Context.MODE_PRIVATE)
+            .getInt(KEY_BG_ALPHA, 0);
+}
+
+/** Persists a new widget background alpha value (0-255). */
+public static void setWidgetBgAlpha(int alpha) {
+    Applic.app
+            .getSharedPreferences(PREFS, Context.MODE_PRIVATE)
+            .edit().putInt(KEY_BG_ALPHA, Math.max(0, Math.min(255, alpha))).apply();
+}
 final private Bitmap glucoseBitmap;
 final private Canvas canvas;
 final private Paint glucosePaint;
@@ -117,13 +185,26 @@ RemoteGlucose(float gl,float notwidth,float xper,int whiteonblack,boolean giveti
 }
 
 static final String stopalarmAction= "StopAlarm";
+
+/**
+ * Returns only the arrow+value Bitmap that arrowremote() paints into the shared canvas.
+ * Used by Notify.buildAlarmBigView() to populate alarm_big.xml without obtaining a
+ * full RemoteViews anchored to the wrong layout resource id.
+ */
+final Bitmap buildArrowValueBitmap(int kind, notGlucose glucose) {
+    // Run the full arrowremote paint path (alarm=true) — it populates glucoseBitmap
+    arrowremote(kind, glucose, true);
+    // Return a copy so the caller owns it independently of the shared canvas.
+    return glucoseBitmap.copy(glucoseBitmap.getConfig(), false);
+}
+
 final RemoteViews arrowremote(int kind, notGlucose glucose,final boolean alarm) {
    RemoteViews remoteViews= new RemoteViews(Applic.app.getPackageName(),alarm?R.layout.alarm:R.layout.arrowandvalue);
    if(alarm) {
       Intent closeintent=new Intent(Applic.app,NumAlarm.class);
       closeintent.setAction(stopalarmAction);
       PendingIntent closepending=PendingIntent.getBroadcast(Applic.app, stopalarmrequest, closeintent,PendingIntent.FLAG_UPDATE_CURRENT|penmutable);
-      remoteViews.setOnClickPendingIntent(R.id.stopalarm, closepending); 
+      remoteViews.setOnClickPendingIntent(R.id.stopalarm, closepending);
       }
    if(glucose==null||glucose.value==null) {
       return remoteViews;
@@ -145,6 +226,10 @@ final RemoteViews arrowremote(int kind, notGlucose glucose,final boolean alarm) 
       drawarrow(canvas, glucosePaint, usedensity, rate, getx * .85f, arrowy);
    }
 
+   // Apply range colour; alarm widgets keep the original paint colour
+   if (!alarm) {
+       glucosePaint.setColor(glucoseRangeColor(SuperGattCallback.previousglucosevalue));
+   }
    canvas.drawText(glucose.value, getx, gety, glucosePaint);
    final boolean glucosealarm=kind<2||kind>4;
    if(kind<50) {
@@ -167,4 +252,162 @@ final RemoteViews arrowremote(int kind, notGlucose glucose,final boolean alarm) 
    remoteViews.setImageViewBitmap(arrowandvalue, glucoseBitmap);
    return remoteViews;
    }
+
+/**
+ * Renders three rows: glucose value (range-coloured), Δ delta, and elapsed-time minutes.
+ * Uses the same bitmap/canvas as arrowremote so the same RemoteGlucose instance works.
+ *
+ * @param glucose   current reading (notGlucose)
+ * @param stale     true when the reading is older than glucosetimeout — paints gray with strikethrough
+ */
+final RemoteViews deltaTimeRemote(notGlucose glucose, boolean stale) {
+    return deltaTimeRemote(glucose, stale, 0, 0);
+}
+
+/**
+ * Renders three rows (glucose value, Δ delta, elapsed time) into a fresh bitmap
+ * sized to the actual widget cell dimensions so the image fills the cell cleanly.
+ *
+ * @param glucose    current reading
+ * @param stale      true when reading is older than glucosetimeout
+ * @param bitmapW    widget width in pixels (0 = fall back to shared bitmap width)
+ * @param bitmapH    widget height in pixels (0 = fall back to square)
+ */
+final RemoteViews deltaTimeRemote(notGlucose glucose, boolean stale,
+                                   int bitmapW, int bitmapH) {
+   RemoteViews remoteViews = new RemoteViews(Applic.app.getPackageName(), R.layout.glucose_delta_widget);
+   if (glucose == null || glucose.value == null) {
+       return remoteViews;
+   }
+
+   // Use a fresh, correctly-sized bitmap so the image fills the widget cell.
+   final int bw = bitmapW > 0 ? bitmapW : glucoseBitmap.getWidth();
+   final int bh = bitmapH > 0 ? bitmapH : bw;
+   final Bitmap bmp = Bitmap.createBitmap(bw, bh, Bitmap.Config.ARGB_8888);
+   final Canvas cv  = new Canvas(bmp);
+   cv.drawColor(Color.TRANSPARENT, PorterDuff.Mode.CLEAR);
+
+   final float w    = bw;
+   final float h    = bh;
+
+   // Layout proportions (matching GDH style):
+   //  top 50%: glucose value (large) + trend arrow side by side
+   //  next 25%: Δ delta (same color as value, bold)
+   //  bottom 25%: elapsed time (white/bright, bold, visible on any background)
+
+   final float basePx    = Math.min(w, h);
+   final float valueSize = basePx * 0.40f;   // large glucose value
+   final float smallSize = basePx * 0.20f;   // delta row
+   final float timeSize  = basePx * 0.18f;   // elapsed time row
+
+   final Paint paint = new Paint();
+   paint.setAntiAlias(true);
+   paint.setFakeBoldText(true);
+   paint.setTextAlign(Paint.Align.CENTER);
+   paint.setTypeface(glucosePaint.getTypeface());
+
+   final int valueColor = stale ? Color.GRAY : glucoseRangeColor(SuperGattCallback.previousglucosevalue);
+
+   // ── glucose value (top area, horizontally centred) ───────────
+   paint.setTextSize(valueSize);
+   paint.setColor(valueColor);
+   final Rect vBounds = new Rect();
+   paint.getTextBounds(glucose.value, 0, glucose.value.length(), vBounds);
+   // Place value baseline so text is in the top 50% of the cell
+   final float valueTopPad = h * 0.04f;
+   final float valueY = valueTopPad + vBounds.height();
+
+   // Draw trend arrow to the right of the glucose number
+   final float rate = glucose.rate;
+   final float arrowAreaW = w * 0.38f;   // right 38% reserved for arrow
+   final float glucoseCx  = w * 0.38f;   // centre of glucose text area
+   cv.drawText(glucose.value, glucoseCx, valueY, paint);
+
+   // Strikethrough if stale
+   if (stale) {
+       final float strikeY = valueY - vBounds.height() * 0.35f;
+       final float sw = paint.getStrokeWidth();
+       paint.setStrokeWidth(Math.max(3f, valueSize * 0.06f));
+       cv.drawLine(glucoseCx - vBounds.width() * 0.55f, strikeY,
+                   glucoseCx + vBounds.width() * 0.55f, strikeY, paint);
+       paint.setStrokeWidth(sw);
+   }
+
+   // ── trend arrow ───────────────────────────────────────────────
+   if (!Float.isNaN(rate)) {
+       paint.setColor(valueColor);
+       paint.setTextSize(valueSize);
+       // density for drawarrow: based on arrow area height
+       final float arrowDensity = valueSize / 54.0f;
+       final float arrowX = w * 0.78f;
+       final float weightrate = (rate > 1.6f ? -1.0f : (rate < -1.6f ? 1.0f : (rate / -1.6f)));
+       final float arrowY = valueY - valueSize * 0.4f + weightrate * valueSize * 0.4f;
+       CommonCanvas.drawarrow(cv, paint, arrowDensity, rate, arrowX, arrowY);
+   }
+
+   // ── delta row ─────────────────────────────────────────────────
+   paint.setTextSize(smallSize);
+   paint.setColor(valueColor);
+   paint.setFakeBoldText(true);
+   final float delta5 = glucose.rate * 5f;
+   final String deltaStr;
+   if (Float.isNaN(delta5)) {
+       deltaStr = "\u0394 --";
+   } else {
+       final String fmt = Applic.unit == 1 ? "%+.1f" : "%+.0f";
+       deltaStr = "\u0394 " + String.format(Applic.usedlocale, fmt, delta5);
+   }
+   final Rect dBounds = new Rect();
+   paint.getTextBounds(deltaStr, 0, deltaStr.length(), dBounds);
+   final float deltaY = h * 0.62f + dBounds.height() * 0.5f;
+   cv.drawText(deltaStr, w * 0.5f, deltaY, paint);
+
+   // ── elapsed-time row — bold, WHITE so it's always readable ───
+   paint.setTextSize(timeSize);
+   paint.setFakeBoldText(true);
+   // Use the notification foreground color (white on dark) for maximum visibility
+   paint.setColor(Notify.foregroundcolor != android.graphics.Color.BLACK
+           ? Notify.foregroundcolor : Color.WHITE);
+   final long elapsedMin = (System.currentTimeMillis() - glucose.time) / 60_000L;
+   final String timeStr  = elapsedMin + " min";
+   final Rect tBounds = new Rect();
+   paint.getTextBounds(timeStr, 0, timeStr.length(), tBounds);
+   final float timeY = h * 0.88f + tBounds.height() * 0.5f;
+   cv.drawText(timeStr, w * 0.5f, timeY, paint);
+
+   remoteViews.setImageViewBitmap(arrowandvalue, bmp);
+   return remoteViews;
+}
+
+/**
+ * Renders the last known glucose value with a horizontal strikethrough line,
+ * used when the reading is stale (older than glucosetimeout).
+ */
+final RemoteViews staleRemote(notGlucose glucose) {
+   RemoteViews remoteViews = new RemoteViews(Applic.app.getPackageName(), R.layout.arrowandvalue);
+   if (glucose == null || glucose.value == null) {
+       return remoteViews;
+   }
+   canvas.drawColor(Color.TRANSPARENT, PorterDuff.Mode.CLEAR);
+   glucosePaint.setTextSize(glucosesize);
+   glucosePaint.setColor(Color.GRAY);
+
+   // Draw the value text
+   final var gety = (canvas.getHeight() - timeHeight) * 0.98f;
+   canvas.drawText(glucose.value, notglucosex, gety, glucosePaint);
+
+   // Overlay a strikethrough line across the text bounds
+   final float valwidth = glucosePaint.measureText(glucose.value);
+   final float lineY = gety - glucosesize * 0.35f;
+   final float strokeW = glucosePaint.getStrokeWidth();
+   glucosePaint.setStrokeWidth(Math.max(3f, glucosesize * 0.06f));
+   canvas.drawLine(notglucosex - glucosesize * 0.05f, lineY,
+                   notglucosex + valwidth + glucosesize * 0.1f, lineY,
+                   glucosePaint);
+   glucosePaint.setStrokeWidth(strokeW);
+
+   canvas.setBitmap(glucoseBitmap);
+   remoteViews.setImageViewBitmap(arrowandvalue, glucoseBitmap);
+   return remoteViews;
+}
 }

--- a/Common/src/main/java/tk/glucodata/keeprunning.java
+++ b/Common/src/main/java/tk/glucodata/keeprunning.java
@@ -71,8 +71,12 @@ static PowerManager.WakeLock wakeLock =null;
        started=true;
        Applic app=(Applic) getApplicationContext();
        app.initproc();
-       if(Natives.getfloatglucose()&&!Natives.gethidefloatinJuggluco()) 
+       if(Natives.getfloatglucose()&&!Natives.gethidefloatinJuggluco())
                 Floating.makefloat();
+        // Restore lock-screen wallpaper state from SharedPreferences
+        if(!isWearable) LockScreenWallpaper.restoreOnBoot();
+        // Restore alarm snooze state
+        AlarmSnooze.init();
         try {
           if(intent==null) {
              if(!Applic.possiblybluetooth(this)) {
@@ -84,7 +88,14 @@ static PowerManager.WakeLock wakeLock =null;
                 }
              }
              theservice=this;
+             // Post the generic "Connecting" foreground notification first (satisfies Android's
+             // 5-second startForeground requirement), then immediately replace it with the
+             // glucose card (v7: foreground service notification cannot be grouped/collapsed).
              Notify.foregroundnot(this);
+             // Initialise persistent glucose notification channel (phone-only, no-op on wear).
+             // Called AFTER theservice is set so startForeground(NOTIF_ID) takes effect here
+             // and our glucose card becomes the foreground service notification immediately.
+             PermanentGlucoseNotification.init(this);
              return Service.START_STICKY;
             } 
         catch(Throwable e) {

--- a/Common/src/main/java/tk/glucodata/settings/Settings.java
+++ b/Common/src/main/java/tk/glucodata/settings/Settings.java
@@ -62,6 +62,7 @@ import static tk.glucodata.util.getlocale;
 
 import android.annotation.SuppressLint;
 import android.app.Activity;
+import androidx.appcompat.app.AlertDialog;
 import android.app.Application;
 import android.content.ComponentName;
 import android.content.Context;
@@ -102,7 +103,9 @@ import androidx.recyclerview.widget.RecyclerView;
 
 import java.text.DecimalFormatSymbols;
 import java.util.Arrays;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 import tk.glucodata.Applic;
 import tk.glucodata.Backup;
@@ -123,6 +126,11 @@ import tk.glucodata.MeterList;
 import tk.glucodata.Natives;
 import tk.glucodata.Notify;
 import tk.glucodata.NumAlarm;
+import tk.glucodata.AlarmLockScreenActivity;
+import tk.glucodata.AlarmSnooze;
+import tk.glucodata.LockScreenWallpaper;
+import tk.glucodata.PermanentGlucoseNotification;
+import tk.glucodata.RemoteGlucose;
 import tk.glucodata.R;
 import tk.glucodata.Specific;
 import tk.glucodata.SuperGattCallback;
@@ -132,6 +140,130 @@ import java.util.Locale;
 
 public class Settings  {
 private final static String LOG_ID="Settings";
+
+/** Update the cancel-snooze button label to show snooze status. */
+private static void updateSnoozeBtnLabel(android.widget.Button btn, android.content.Context ctx) {
+    if (AlarmSnooze.isActive()) {
+        btn.setText(ctx.getString(R.string.snooze_cancel) + " (" + AlarmSnooze.snoozeUntilText() + ")");
+        btn.setAlpha(1.0f);
+    } else {
+        btn.setText(R.string.snooze_cancel);
+        btn.setAlpha(0.4f);   // dimmed — no active snooze to cancel
+    }
+}
+
+/** Update the snooze-button picker label to show the current selection. */
+private static void updateSnoozeBtnPickerLabel(android.widget.Button btn, android.content.Context ctx) {
+    final List<Long> vals = AlarmSnooze.getSnoozeButtons();
+    if (vals.isEmpty()) {
+        btn.setText(ctx.getString(R.string.snooze_buttons_title) + ": —");
+    } else {
+        final StringBuilder sb = new StringBuilder(ctx.getString(R.string.snooze_buttons_title) + ": ");
+        for (int i = 0; i < vals.size(); i++) {
+            if (i > 0) sb.append(", ");
+            sb.append(vals.get(i));
+        }
+        btn.setText(sb.toString());
+    }
+}
+
+/**
+ * Show a multi-choice AlertDialog for picking snooze durations (30/60/90/120 min,
+ * up to 3 selected). On confirm, saves to AlarmSnooze and refreshes the button label.
+ */
+private static void showSnoozeBtnDialog(android.content.Context ctx, android.widget.Button pickerBtn) {
+    final long[] all = AlarmSnooze.ALL_DURATIONS;  // {30, 60, 90, 120}
+    final int[] labelIds = {R.string.snooze_30, R.string.snooze_60, R.string.snooze_90, R.string.snooze_120};
+    // getSnoozeButtonsRaw() may return the live SharedPreferences set — copy it defensively
+    final Set<String> current = new HashSet<>(AlarmSnooze.getSnoozeButtonsRaw());
+    final boolean[] checked = new boolean[all.length];
+    final String[] labels = new String[all.length];
+    for (int i = 0; i < all.length; i++) {
+        labels[i] = ctx.getString(labelIds[i]);
+        checked[i] = current.contains(String.valueOf(all[i]));
+    }
+    // working copy so Cancel discards changes
+    final boolean[] working = checked.clone();
+
+    // NOTE: setMessage and setMultiChoiceItems compete for the same content area —
+    // do NOT use both. Title alone is sufficient; the items are self-explanatory.
+    // Wrap context with light dialog theme so list text is dark on the white background.
+    final android.view.ContextThemeWrapper themedCtx =
+            new android.view.ContextThemeWrapper(ctx, R.style.MyLightAlertDialogTheme);
+    new AlertDialog.Builder(themedCtx)
+        .setTitle(R.string.snooze_buttons_title)
+        .setMultiChoiceItems(labels, working, (dialog, which, isChecked) -> {
+            if (isChecked) {
+                // Count how many OTHER items are already checked (excluding this one)
+                int count = 0;
+                for (int i = 0; i < working.length; i++) if (i != which && working[i]) count++;
+                if (count >= 3) {
+                    // Already at limit — reject this check and uncheck it in the UI
+                    working[which] = false;
+                    ((AlertDialog) dialog).getListView()
+                            .setItemChecked(which, false);
+                    android.widget.Toast.makeText(ctx,
+                            R.string.snooze_max_3, android.widget.Toast.LENGTH_SHORT).show();
+                    return;
+                }
+            }
+            working[which] = isChecked;
+        })
+        .setPositiveButton(R.string.ok, (dialog, which) -> {
+            final Set<String> selected = new HashSet<>();
+            for (int i = 0; i < all.length; i++) {
+                if (working[i]) selected.add(String.valueOf(all[i]));
+            }
+            AlarmSnooze.setSnoozeButtons(selected);
+            updateSnoozeBtnPickerLabel(pickerBtn, ctx);
+        })
+        .setNegativeButton(R.string.cancel, null)
+        .show();
+}
+
+// ── Widget background alpha helpers ──────────────────────────────────────
+
+private static void updateWidgetBgBtnLabel(android.widget.Button btn, android.content.Context ctx) {
+    final int alpha = RemoteGlucose.getWidgetBgAlpha();
+    final String label;
+    if (alpha <= 0)       label = ctx.getString(R.string.widget_bg_alpha_none);
+    else if (alpha <= 64) label = ctx.getString(R.string.widget_bg_alpha_light);
+    else if (alpha <= 128)label = ctx.getString(R.string.widget_bg_alpha_medium);
+    else                  label = ctx.getString(R.string.widget_bg_alpha_dark);
+    btn.setText(ctx.getString(R.string.widget_bg_alpha_title) + ": " + label);
+}
+
+private static void showWidgetBgDialog(android.content.Context ctx, android.widget.Button btn) {
+    final int[] alphaValues = {0, 64, 128, 191};   // 0 / 25% / 50% / 75%
+    final int[] labelIds = {
+        R.string.widget_bg_alpha_none,
+        R.string.widget_bg_alpha_light,
+        R.string.widget_bg_alpha_medium,
+        R.string.widget_bg_alpha_dark
+    };
+    final int current = RemoteGlucose.getWidgetBgAlpha();
+    int checkedItem = 0;
+    final String[] labels = new String[alphaValues.length];
+    for (int i = 0; i < alphaValues.length; i++) {
+        labels[i] = ctx.getString(labelIds[i]);
+        if (current >= alphaValues[i] - 32 && current <= alphaValues[i] + 32) checkedItem = i;
+    }
+    final int[] selected = {checkedItem};
+    final android.view.ContextThemeWrapper themedCtx =
+            new android.view.ContextThemeWrapper(ctx, R.style.MyLightAlertDialogTheme);
+    new AlertDialog.Builder(themedCtx)
+        .setTitle(R.string.widget_bg_alpha_title)
+        .setSingleChoiceItems(labels, checkedItem, (dialog, which) -> selected[0] = which)
+        .setPositiveButton(R.string.ok, (dialog, which) -> {
+            RemoteGlucose.setWidgetBgAlpha(alphaValues[selected[0]]);
+            updateWidgetBgBtnLabel(btn, ctx);
+        })
+        .setNegativeButton(R.string.cancel, null)
+        .show();
+}
+
+
+
 MainActivity activity;
 
 /*
@@ -810,9 +942,28 @@ new View[]{isvalue},new View[]{ringisvalue},new View[]{usealarm},new View[]{adva
         getMargins(help).setMarginStart(marg);
         getMargins(Save).setMarginEnd(marg);
 
+        // ── Snooze controls (moved from main Settings) ──────────────────────
+        final android.widget.Button snoozeBtnsPicker = getbutton(context, R.string.snooze_buttons_title);
+        updateSnoozeBtnPickerLabel(snoozeBtnsPicker, context);
+        snoozeBtnsPicker.setOnClickListener(v -> showSnoozeBtnDialog(context, snoozeBtnsPicker));
 
-        views=new View[][]{lowalarm,highalarm,lostrow,row6,rowshow};
-        }    
+        android.widget.Button cancelSnoozeBtn = getbutton(context, R.string.snooze_cancel);
+        updateSnoozeBtnLabel(cancelSnoozeBtn, context);
+        cancelSnoozeBtn.setOnClickListener(v -> {
+            if (AlarmSnooze.isActive()) {
+                AlarmSnooze.set(0);
+                updateSnoozeBtnLabel(cancelSnoozeBtn, context);
+                android.widget.Toast.makeText(context,
+                        R.string.snooze_cancelled, android.widget.Toast.LENGTH_SHORT).show();
+            } else {
+                android.widget.Toast.makeText(context,
+                        R.string.snooze_not_active, android.widget.Toast.LENGTH_SHORT).show();
+            }
+        });
+        View[] rowSnooze = new View[]{snoozeBtnsPicker, cancelSnoozeBtn};
+
+        views=new View[][]{lowalarm,highalarm,lostrow,row6,rowSnooze,rowshow};
+        }
     View lay;
         Layout layout = new Layout(context, (l, w, h) -> {
             hideSystemUI();
@@ -1432,9 +1583,50 @@ private    void mksettings(MainActivity context) {
                 }
         floatconfig.setOnClickListener(v-> tk.glucodata.FloatingConfig.show(context,thelayout[0]));
 
+        // ── Dev enhancements: Lock Screen Wallpaper + Alarm Lock Screen ───────
+        CheckDirectionBox lockscreenWp = new CheckDirectionBox(context);
+        lockscreenWp.setText(R.string.lockscreen_wallpaper);
+        lockscreenWp.setChecked(LockScreenWallpaper.isEnabled());
+        lockscreenWp.setOnCheckedChangeListener((buttonView, isChecked) ->
+                LockScreenWallpaper.setEnabled(isChecked));
+
+        CheckDirectionBox alarmLockscreen = new CheckDirectionBox(context);
+        alarmLockscreen.setText(R.string.alarm_lockscreen);
+        alarmLockscreen.setChecked(AlarmLockScreenActivity.isEnabled());
+        alarmLockscreen.setOnCheckedChangeListener((buttonView, isChecked) ->
+                AlarmLockScreenActivity.setEnabled(isChecked));
+
+        // ── Persistent glucose notification (lock-screen card) ────────────────
+        CheckDirectionBox permanentNotif = new CheckDirectionBox(context);
+        permanentNotif.setText(R.string.permanent_glucose_notif);
+        permanentNotif.setChecked(PermanentGlucoseNotification.isEnabled());
+        permanentNotif.setOnCheckedChangeListener((buttonView, isChecked) ->
+                PermanentGlucoseNotification.setEnabled(isChecked));
+
+        // ── Widget background alpha picker ────────────────────────────────────
+        Button widgetBgBtn = getbutton(context, R.string.widget_bg_alpha_title);
+        updateWidgetBgBtnLabel(widgetBgBtn, context);
+        widgetBgBtn.setOnClickListener(v -> showWidgetBgDialog(context, widgetBgBtn));
+
+        // ── Full-screen alarm permission button (Android 14+ only) ────────────
+        // On Android 14 (API 34) USE_FULL_SCREEN_INTENT requires explicit approval.
+        // Without it, AlarmLockScreenActivity never pops up during gaming / fullscreen
+        // apps.  Show a one-tap button that opens the system Settings page for it.
+        View[] rowDevEnhancements2;
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE
+                && !AlarmLockScreenActivity.hasFullScreenIntentPermission()) {
+            Button fsPermBtn = getbutton(context, R.string.alarm_fullscreen_grant);
+            fsPermBtn.setOnClickListener(v ->
+                    AlarmLockScreenActivity.requestFullScreenIntentPermission(context));
+            rowDevEnhancements2 = new View[]{widgetBgBtn, fsPermBtn};
+        } else {
+            rowDevEnhancements2 = new View[]{widgetBgBtn};
+        }
+
         View[] rowglu=new View[]{floatconfig,calibration,glucosenotify};
 //        View[] rowglu=new View[]{floatconfig,glucosenotify};
-        views=new View[][]{row0, hasnfc?new View[]{nfcsound, globalscan,camera}:null,rowglu,new View[]{exchanges,numalarm,alarmbut},numdis, row9};
+        View[] rowDevEnhancements  = new View[]{lockscreenWp, alarmLockscreen, permanentNotif};
+        views=new View[][]{row0, hasnfc?new View[]{nfcsound, globalscan,camera}:null,rowglu,rowDevEnhancements,rowDevEnhancements2,new View[]{exchanges,numalarm,alarmbut},numdis, row9};
         }
 
     help.setFocusableInTouchMode(true);

--- a/Common/src/main/res/drawable/lockscreen_wallpaper_bg.xml
+++ b/Common/src/main/res/drawable/lockscreen_wallpaper_bg.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+    Background drawable for the lock-screen wallpaper card.
+    Semi-transparent dark rounded rectangle so the user's lock-screen
+    photo remains visible around the card.
+
+    #88000000 = ~53 % alpha black (close to GDH's #55000000 but slightly more
+    opaque so the card is clearly readable against any wallpaper).
+-->
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+    <solid android:color="#88000000" />
+    <corners android:radius="24dp" />
+</shape>

--- a/Common/src/main/res/layout/alarm_big.xml
+++ b/Common/src/main/res/layout/alarm_big.xml
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+    Expanded (big-content) view for the alarm notification.
+    Shows the same arrow+value row as alarm.xml, then a 3-hour glucose history
+    graph below it, and the snooze action buttons underneath (supplied as
+    Notification.Action entries by the builder, not in this layout).
+-->
+<LinearLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/notification"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="vertical">
+
+    <!-- ── Top row: arrow+value bitmap | Stop button ── -->
+    <RelativeLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content">
+
+        <ImageView
+            android:id="@+id/arrowandvalue"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_alignParentLeft="true"
+            android:layout_toLeftOf="@+id/stopalarm"
+            android:layout_centerVertical="true"
+            android:layout_marginLeft="0dp"
+            android:paddingTop="0dp"
+            android:paddingBottom="0dp"
+            android:layout_marginTop="0dp"
+            android:layout_marginBottom="0dp" />
+
+        <Button
+            android:id="@+id/stopalarm"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_alignParentRight="true"
+            android:layout_centerVertical="true"
+            android:minHeight="0dp"
+            android:minWidth="0dp"
+            android:text="@string/shortoff" />
+
+    </RelativeLayout>
+
+    <!-- ── Graph row: 3-hour glucose history (shown only in expanded view) ── -->
+    <ImageView
+        android:id="@+id/alarm_graph"
+        android:layout_width="match_parent"
+        android:layout_height="100dp"
+        android:scaleType="fitXY"
+        android:adjustViewBounds="false"
+        android:visibility="gone"
+        android:contentDescription="@string/glucose_graph_desc" />
+
+</LinearLayout>

--- a/Common/src/main/res/layout/chart_glucose_widget.xml
+++ b/Common/src/main/res/layout/chart_glucose_widget.xml
@@ -1,0 +1,102 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+    Layout for ChartGlucoseWidget — "normal" size (default).
+    Structure (vertical):
+      Row 1 (weight 2): glucose value (weight 3) | trend arrow (weight 2)
+      Row 2 (weight 1): 🕒 time (weight 1)       | Δ delta (weight 1)
+      Row 3 (weight 3): glucose history graph bitmap
+    IDs all prefixed cgw_ (chart glucose widget).
+    Colors are set dynamically in ChartGlucoseWidget.java.
+-->
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/cgw_root"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical"
+    android:background="@android:color/transparent">
+
+    <!-- Row 1: glucose value + trend arrow -->
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:layout_weight="2"
+        android:layout_marginLeft="6dp"
+        android:layout_marginRight="6dp"
+        android:layout_marginTop="4dp"
+        android:orientation="horizontal">
+
+        <TextView
+            android:id="@+id/cgw_glucose"
+            android:layout_width="0dp"
+            android:layout_height="match_parent"
+            android:layout_weight="3"
+            android:gravity="center"
+            android:maxLines="1"
+            android:autoSizeTextType="uniform"
+            android:autoSizeMinTextSize="1sp"
+            android:autoSizeMaxTextSize="120sp"
+            android:autoSizeStepGranularity="1sp"
+            android:text="---" />
+
+        <ImageView
+            android:id="@+id/cgw_arrow"
+            android:layout_width="0dp"
+            android:layout_height="match_parent"
+            android:layout_weight="2"
+            android:layout_marginStart="4dp"
+            android:scaleType="fitCenter"
+            android:contentDescription="Trend" />
+
+    </LinearLayout>
+
+    <!-- Row 2: elapsed time | delta -->
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:layout_weight="1"
+        android:layout_marginLeft="6dp"
+        android:layout_marginRight="6dp"
+        android:orientation="horizontal">
+
+        <TextView
+            android:id="@+id/cgw_time"
+            android:layout_width="0dp"
+            android:layout_height="match_parent"
+            android:layout_weight="1"
+            android:gravity="center"
+            android:maxLines="1"
+            android:autoSizeTextType="uniform"
+            android:autoSizeMinTextSize="1sp"
+            android:autoSizeMaxTextSize="20sp"
+            android:autoSizeStepGranularity="1sp"
+            android:text="🕒 0 min" />
+
+        <TextView
+            android:id="@+id/cgw_delta"
+            android:layout_width="0dp"
+            android:layout_height="match_parent"
+            android:layout_weight="1"
+            android:gravity="center"
+            android:maxLines="1"
+            android:autoSizeTextType="uniform"
+            android:autoSizeMinTextSize="1sp"
+            android:autoSizeMaxTextSize="20sp"
+            android:autoSizeStepGranularity="1sp"
+            android:text="\u0394 +0" />
+
+    </LinearLayout>
+
+    <!-- Row 3: glucose history graph -->
+    <ImageView
+        android:id="@+id/cgw_graph"
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:layout_weight="3"
+        android:layout_marginLeft="4dp"
+        android:layout_marginRight="4dp"
+        android:layout_marginBottom="4dp"
+        android:scaleType="fitXY"
+        android:contentDescription="Glucose graph"
+        android:visibility="gone" />
+
+</LinearLayout>

--- a/Common/src/main/res/layout/chart_glucose_widget_long.xml
+++ b/Common/src/main/res/layout/chart_glucose_widget_long.xml
@@ -1,0 +1,107 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+    Layout for ChartGlucoseWidget — "long" variant.
+    Used when aspect ratio > 2.0 (wide cell).
+    Structure (horizontal split):
+      Left  half (weight 1): vertical stack — glucose | arrow | time | delta
+      Right half (weight 1): glucose history graph bitmap
+-->
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/cgw_root"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="horizontal"
+    android:background="@android:color/transparent">
+
+    <!-- Left panel: value / arrow / time / delta -->
+    <LinearLayout
+        android:layout_width="0dp"
+        android:layout_height="match_parent"
+        android:layout_weight="1"
+        android:layout_marginLeft="6dp"
+        android:layout_marginTop="4dp"
+        android:layout_marginBottom="4dp"
+        android:orientation="vertical">
+
+        <!-- Glucose + arrow row -->
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="0dp"
+            android:layout_weight="2"
+            android:orientation="horizontal">
+
+            <TextView
+                android:id="@+id/cgw_glucose"
+                android:layout_width="0dp"
+                android:layout_height="match_parent"
+                android:layout_weight="3"
+                android:gravity="center"
+                android:maxLines="1"
+                android:autoSizeTextType="uniform"
+                android:autoSizeMinTextSize="1sp"
+                android:autoSizeMaxTextSize="120sp"
+                android:autoSizeStepGranularity="1sp"
+                android:text="---" />
+
+            <ImageView
+                android:id="@+id/cgw_arrow"
+                android:layout_width="0dp"
+                android:layout_height="match_parent"
+                android:layout_weight="2"
+                android:layout_marginStart="4dp"
+                android:scaleType="fitCenter"
+                android:contentDescription="Trend" />
+
+        </LinearLayout>
+
+        <!-- Time + delta row -->
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="0dp"
+            android:layout_weight="1"
+            android:orientation="horizontal">
+
+            <TextView
+                android:id="@+id/cgw_time"
+                android:layout_width="0dp"
+                android:layout_height="match_parent"
+                android:layout_weight="1"
+                android:gravity="center"
+                android:maxLines="1"
+                android:autoSizeTextType="uniform"
+                android:autoSizeMinTextSize="1sp"
+                android:autoSizeMaxTextSize="20sp"
+                android:autoSizeStepGranularity="1sp"
+                android:text="🕒 0 min" />
+
+            <TextView
+                android:id="@+id/cgw_delta"
+                android:layout_width="0dp"
+                android:layout_height="match_parent"
+                android:layout_weight="1"
+                android:gravity="center"
+                android:maxLines="1"
+                android:autoSizeTextType="uniform"
+                android:autoSizeMinTextSize="1sp"
+                android:autoSizeMaxTextSize="20sp"
+                android:autoSizeStepGranularity="1sp"
+                android:text="\u0394 +0" />
+
+        </LinearLayout>
+
+    </LinearLayout>
+
+    <!-- Right panel: glucose history graph -->
+    <ImageView
+        android:id="@+id/cgw_graph"
+        android:layout_width="0dp"
+        android:layout_height="match_parent"
+        android:layout_weight="1"
+        android:layout_marginTop="4dp"
+        android:layout_marginBottom="4dp"
+        android:layout_marginEnd="4dp"
+        android:scaleType="fitXY"
+        android:contentDescription="Glucose graph"
+        android:visibility="gone" />
+
+</LinearLayout>

--- a/Common/src/main/res/layout/chart_glucose_widget_short.xml
+++ b/Common/src/main/res/layout/chart_glucose_widget_short.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+    Layout for ChartGlucoseWidget — "short" variant.
+    Used when cell is narrow (≤ 110 dp wide) or shallow (≤ 70 dp tall).
+    Shows only: glucose value (left) | trend arrow (right)
+    No graph, no time, no delta — same structure as GlucoseTrendWidget.
+-->
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/cgw_root"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="horizontal"
+    android:background="@android:color/transparent">
+
+    <TextView
+        android:id="@+id/cgw_glucose"
+        android:layout_width="0dp"
+        android:layout_height="match_parent"
+        android:layout_weight="3"
+        android:layout_marginLeft="6dp"
+        android:layout_marginTop="4dp"
+        android:layout_marginBottom="4dp"
+        android:gravity="center"
+        android:maxLines="1"
+        android:autoSizeTextType="uniform"
+        android:autoSizeMinTextSize="1sp"
+        android:autoSizeMaxTextSize="120sp"
+        android:autoSizeStepGranularity="1sp"
+        android:text="---" />
+
+    <ImageView
+        android:id="@+id/cgw_arrow"
+        android:layout_width="0dp"
+        android:layout_height="match_parent"
+        android:layout_weight="2"
+        android:layout_marginStart="4dp"
+        android:layout_marginEnd="4dp"
+        android:layout_marginTop="4dp"
+        android:layout_marginBottom="4dp"
+        android:scaleType="fitCenter"
+        android:contentDescription="Trend" />
+
+</LinearLayout>

--- a/Common/src/main/res/layout/glucose_delta_widget.xml
+++ b/Common/src/main/res/layout/glucose_delta_widget.xml
@@ -1,0 +1,90 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+    Layout for the Juggluco GlucoseDeltaTimeWidget.
+    Pixel-exact copy of GDH's glucose_trend_delta_time_widget.xml structure:
+      Row 1 (weight 3): glucose value auto-size (weight 3)  |  trend arrow (weight 2)
+      Row 2 (weight 1): 🕒 time auto-size (weight 1)        |  Δ delta auto-size (weight 1)
+    Text colours are set dynamically in GlucoseDeltaTimeWidget.java.
+-->
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/glucose_delta_widget_root"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical"
+    android:background="@android:color/transparent">
+
+    <!-- Row 1: large glucose number (weight 3) + trend arrow image (weight 2) -->
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:layout_weight="3"
+        android:layout_marginStart="6dp"
+        android:layout_marginEnd="6dp"
+        android:layout_marginTop="6dp"
+        android:minWidth="60dp"
+        android:orientation="horizontal">
+
+        <TextView
+            android:id="@+id/dtw_glucose"
+            android:layout_width="0dp"
+            android:layout_height="match_parent"
+            android:layout_weight="3"
+            android:gravity="center"
+            android:maxLines="1"
+            android:autoSizeTextType="uniform"
+            android:autoSizeMinTextSize="1sp"
+            android:autoSizeMaxTextSize="120sp"
+            android:autoSizeStepGranularity="1sp"
+            android:text="---" />
+
+        <ImageView
+            android:id="@+id/dtw_arrow"
+            android:layout_width="0dp"
+            android:layout_height="match_parent"
+            android:layout_weight="2"
+            android:layout_marginStart="6dp"
+            android:scaleType="fitCenter"
+            android:contentDescription="Trend" />
+
+    </LinearLayout>
+
+    <!-- Row 2: 🕒 time (weight 1) | Δ delta (weight 1) — same order as GDH -->
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:layout_weight="1"
+        android:layout_marginStart="6dp"
+        android:layout_marginEnd="6dp"
+        android:layout_marginBottom="6dp"
+        android:minWidth="60dp"
+        android:orientation="horizontal">
+
+        <TextView
+            android:id="@+id/dtw_time"
+            android:layout_width="0dp"
+            android:layout_height="match_parent"
+            android:layout_weight="1"
+            android:gravity="center"
+            android:maxLines="1"
+            android:autoSizeTextType="uniform"
+            android:autoSizeMinTextSize="1sp"
+            android:autoSizeMaxTextSize="20sp"
+            android:autoSizeStepGranularity="1sp"
+            android:text="🕒 0 min" />
+
+        <TextView
+            android:id="@+id/dtw_delta"
+            android:layout_width="0dp"
+            android:layout_height="match_parent"
+            android:layout_weight="1"
+            android:gravity="center"
+            android:maxLines="1"
+            android:autoSizeTextType="uniform"
+            android:autoSizeMinTextSize="1sp"
+            android:autoSizeMaxTextSize="24sp"
+            android:autoSizeStepGranularity="1sp"
+            android:text="\u0394 +0.0" />
+
+    </LinearLayout>
+
+</LinearLayout>

--- a/Common/src/main/res/layout/glucose_delta_widget_long.xml
+++ b/Common/src/main/res/layout/glucose_delta_widget_long.xml
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/glucose_delta_widget_root"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="horizontal"
+    android:gravity="center_vertical"
+    android:background="@android:color/transparent"
+    android:paddingStart="8dp"
+    android:paddingEnd="8dp"
+    android:paddingTop="6dp"
+    android:paddingBottom="6dp">
+
+    <TextView
+        android:id="@+id/dtw_glucose"
+        android:layout_width="0dp"
+        android:layout_height="match_parent"
+        android:layout_weight="4"
+        android:gravity="center"
+        android:maxLines="1"
+        android:autoSizeTextType="uniform"
+        android:autoSizeMinTextSize="1sp"
+        android:autoSizeMaxTextSize="120sp"
+        android:autoSizeStepGranularity="1sp"
+        android:text="---" />
+
+    <ImageView
+        android:id="@+id/dtw_arrow"
+        android:layout_width="0dp"
+        android:layout_height="match_parent"
+        android:layout_weight="1"
+        android:layout_marginStart="8dp"
+        android:scaleType="fitCenter"
+        android:contentDescription="Trend" />
+
+    <TextView
+        android:id="@+id/dtw_time"
+        android:layout_width="0dp"
+        android:layout_height="match_parent"
+        android:layout_weight="2"
+        android:layout_marginStart="8dp"
+        android:gravity="center"
+        android:maxLines="1"
+        android:autoSizeTextType="uniform"
+        android:autoSizeMinTextSize="1sp"
+        android:autoSizeMaxTextSize="22sp"
+        android:autoSizeStepGranularity="1sp"
+        android:text="🕒 0 min" />
+
+    <TextView
+        android:id="@+id/dtw_delta"
+        android:layout_width="0dp"
+        android:layout_height="match_parent"
+        android:layout_weight="2"
+        android:layout_marginStart="8dp"
+        android:gravity="center"
+        android:maxLines="1"
+        android:autoSizeTextType="uniform"
+        android:autoSizeMinTextSize="1sp"
+        android:autoSizeMaxTextSize="28sp"
+        android:autoSizeStepGranularity="1sp"
+        android:text="Δ +0.0" />
+
+</LinearLayout>

--- a/Common/src/main/res/layout/glucose_delta_widget_short.xml
+++ b/Common/src/main/res/layout/glucose_delta_widget_short.xml
@@ -1,0 +1,79 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/glucose_delta_widget_root"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical"
+    android:background="@android:color/transparent"
+    android:paddingStart="4dp"
+    android:paddingEnd="4dp"
+    android:paddingTop="4dp"
+    android:paddingBottom="4dp">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:layout_weight="2"
+        android:orientation="horizontal"
+        android:gravity="center_vertical">
+
+        <TextView
+            android:id="@+id/dtw_glucose"
+            android:layout_width="0dp"
+            android:layout_height="match_parent"
+            android:layout_weight="3"
+            android:gravity="center"
+            android:maxLines="1"
+            android:autoSizeTextType="uniform"
+            android:autoSizeMinTextSize="1sp"
+            android:autoSizeMaxTextSize="96sp"
+            android:autoSizeStepGranularity="1sp"
+            android:text="---" />
+
+        <ImageView
+            android:id="@+id/dtw_arrow"
+            android:layout_width="0dp"
+            android:layout_height="match_parent"
+            android:layout_weight="1"
+            android:layout_marginStart="4dp"
+            android:scaleType="fitCenter"
+            android:contentDescription="Trend" />
+
+    </LinearLayout>
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:layout_weight="1"
+        android:layout_marginTop="4dp"
+        android:orientation="horizontal">
+
+        <TextView
+            android:id="@+id/dtw_time"
+            android:layout_width="0dp"
+            android:layout_height="match_parent"
+            android:layout_weight="1"
+            android:gravity="center"
+            android:maxLines="1"
+            android:autoSizeTextType="uniform"
+            android:autoSizeMinTextSize="1sp"
+            android:autoSizeMaxTextSize="18sp"
+            android:autoSizeStepGranularity="1sp"
+            android:text="🕒 0 min" />
+
+        <TextView
+            android:id="@+id/dtw_delta"
+            android:layout_width="0dp"
+            android:layout_height="match_parent"
+            android:layout_weight="1"
+            android:gravity="center"
+            android:maxLines="1"
+            android:autoSizeTextType="uniform"
+            android:autoSizeMinTextSize="1sp"
+            android:autoSizeMaxTextSize="22sp"
+            android:autoSizeStepGranularity="1sp"
+            android:text="Δ +0.0" />
+
+    </LinearLayout>
+
+</LinearLayout>

--- a/Common/src/main/res/layout/glucose_trend_delta_widget.xml
+++ b/Common/src/main/res/layout/glucose_trend_delta_widget.xml
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+    Layout for GlucoseTrendDeltaWidget.
+    Row 1 (weight 3): glucose value (weight 3) | trend arrow (weight 2)
+    Row 2 (weight 1): Δ delta centred
+    Equivalent to GDH's glucose_trend_delta_widget.xml.
+    Text colours are set dynamically in GlucoseTrendDeltaWidget.java.
+-->
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/glucose_trend_delta_widget_root"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical"
+    android:background="@android:color/transparent">
+
+    <!-- Row 1: glucose + arrow -->
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:layout_weight="3"
+        android:layout_marginStart="6dp"
+        android:layout_marginEnd="6dp"
+        android:layout_marginTop="6dp"
+        android:orientation="horizontal">
+
+        <TextView
+            android:id="@+id/gtdw_glucose"
+            android:layout_width="0dp"
+            android:layout_height="match_parent"
+            android:layout_weight="3"
+            android:gravity="center"
+            android:maxLines="1"
+            android:autoSizeTextType="uniform"
+            android:autoSizeMinTextSize="1sp"
+            android:autoSizeMaxTextSize="120sp"
+            android:autoSizeStepGranularity="1sp"
+            android:text="---" />
+
+        <ImageView
+            android:id="@+id/gtdw_arrow"
+            android:layout_width="0dp"
+            android:layout_height="match_parent"
+            android:layout_weight="2"
+            android:layout_marginStart="6dp"
+            android:scaleType="fitCenter"
+            android:contentDescription="Trend" />
+
+    </LinearLayout>
+
+    <!-- Row 2: delta -->
+    <TextView
+        android:id="@+id/gtdw_delta"
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:layout_weight="1"
+        android:layout_marginStart="6dp"
+        android:layout_marginEnd="6dp"
+        android:layout_marginBottom="6dp"
+        android:gravity="center"
+        android:maxLines="1"
+        android:autoSizeTextType="uniform"
+        android:autoSizeMinTextSize="1sp"
+        android:autoSizeMaxTextSize="28sp"
+        android:autoSizeStepGranularity="1sp"
+        android:text="\u0394 +0.0" />
+
+</LinearLayout>

--- a/Common/src/main/res/layout/glucose_trend_delta_widget_long.xml
+++ b/Common/src/main/res/layout/glucose_trend_delta_widget_long.xml
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/glucose_trend_delta_widget_root"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="horizontal"
+    android:gravity="center_vertical"
+    android:background="@android:color/transparent"
+    android:paddingStart="8dp"
+    android:paddingEnd="8dp"
+    android:paddingTop="6dp"
+    android:paddingBottom="6dp">
+
+    <TextView
+        android:id="@+id/gtdw_glucose"
+        android:layout_width="0dp"
+        android:layout_height="match_parent"
+        android:layout_weight="4"
+        android:gravity="center"
+        android:maxLines="1"
+        android:autoSizeTextType="uniform"
+        android:autoSizeMinTextSize="1sp"
+        android:autoSizeMaxTextSize="120sp"
+        android:autoSizeStepGranularity="1sp"
+        android:text="---" />
+
+    <ImageView
+        android:id="@+id/gtdw_arrow"
+        android:layout_width="0dp"
+        android:layout_height="match_parent"
+        android:layout_weight="1"
+        android:layout_marginStart="8dp"
+        android:scaleType="fitCenter"
+        android:contentDescription="Trend" />
+
+    <TextView
+        android:id="@+id/gtdw_delta"
+        android:layout_width="0dp"
+        android:layout_height="match_parent"
+        android:layout_weight="2"
+        android:layout_marginStart="8dp"
+        android:gravity="center"
+        android:maxLines="1"
+        android:autoSizeTextType="uniform"
+        android:autoSizeMinTextSize="1sp"
+        android:autoSizeMaxTextSize="32sp"
+        android:autoSizeStepGranularity="1sp"
+        android:text="Δ +0.0" />
+
+</LinearLayout>

--- a/Common/src/main/res/layout/glucose_trend_delta_widget_short.xml
+++ b/Common/src/main/res/layout/glucose_trend_delta_widget_short.xml
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/glucose_trend_delta_widget_root"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical"
+    android:background="@android:color/transparent"
+    android:paddingStart="4dp"
+    android:paddingEnd="4dp"
+    android:paddingTop="4dp"
+    android:paddingBottom="4dp">
+
+    <TextView
+        android:id="@+id/gtdw_glucose"
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:layout_weight="2"
+        android:gravity="center"
+        android:maxLines="1"
+        android:autoSizeTextType="uniform"
+        android:autoSizeMinTextSize="1sp"
+        android:autoSizeMaxTextSize="96sp"
+        android:autoSizeStepGranularity="1sp"
+        android:text="---" />
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:layout_weight="1"
+        android:layout_marginTop="4dp"
+        android:orientation="horizontal"
+        android:gravity="center_vertical">
+
+        <ImageView
+            android:id="@+id/gtdw_arrow"
+            android:layout_width="0dp"
+            android:layout_height="match_parent"
+            android:layout_weight="1"
+            android:layout_marginEnd="4dp"
+            android:scaleType="fitCenter"
+            android:contentDescription="Trend" />
+
+        <TextView
+            android:id="@+id/gtdw_delta"
+            android:layout_width="0dp"
+            android:layout_height="match_parent"
+            android:layout_weight="2"
+            android:gravity="center"
+            android:maxLines="1"
+            android:autoSizeTextType="uniform"
+            android:autoSizeMinTextSize="1sp"
+            android:autoSizeMaxTextSize="24sp"
+            android:autoSizeStepGranularity="1sp"
+            android:text="Δ +0.0" />
+
+    </LinearLayout>
+
+</LinearLayout>

--- a/Common/src/main/res/layout/glucose_trend_widget.xml
+++ b/Common/src/main/res/layout/glucose_trend_widget.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+    Layout for GlucoseTrendWidget.
+    Single row: large glucose value (weight 3) | trend arrow (weight 2).
+    Equivalent to GDH's glucose_trend_widget.xml.
+    Text colours are set dynamically in GlucoseTrendWidget.java.
+-->
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/glucose_trend_widget_root"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="horizontal"
+    android:gravity="center_vertical"
+    android:background="@android:color/transparent">
+
+    <TextView
+        android:id="@+id/gtw_glucose"
+        android:layout_width="0dp"
+        android:layout_height="match_parent"
+        android:layout_weight="3"
+        android:layout_marginStart="6dp"
+        android:layout_marginTop="6dp"
+        android:layout_marginBottom="6dp"
+        android:gravity="center"
+        android:maxLines="1"
+        android:autoSizeTextType="uniform"
+        android:autoSizeMinTextSize="1sp"
+        android:autoSizeMaxTextSize="120sp"
+        android:autoSizeStepGranularity="1sp"
+        android:text="---" />
+
+    <ImageView
+        android:id="@+id/gtw_arrow"
+        android:layout_width="0dp"
+        android:layout_height="match_parent"
+        android:layout_weight="2"
+        android:layout_marginStart="6dp"
+        android:layout_marginEnd="6dp"
+        android:layout_marginTop="6dp"
+        android:layout_marginBottom="6dp"
+        android:scaleType="fitCenter"
+        android:contentDescription="Trend" />
+
+</LinearLayout>

--- a/Common/src/main/res/layout/glucose_trend_widget_long.xml
+++ b/Common/src/main/res/layout/glucose_trend_widget_long.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/glucose_trend_widget_root"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="horizontal"
+    android:gravity="center_vertical"
+    android:background="@android:color/transparent"
+    android:paddingStart="8dp"
+    android:paddingEnd="8dp"
+    android:paddingTop="6dp"
+    android:paddingBottom="6dp">
+
+    <TextView
+        android:id="@+id/gtw_glucose"
+        android:layout_width="0dp"
+        android:layout_height="match_parent"
+        android:layout_weight="4"
+        android:gravity="center"
+        android:maxLines="1"
+        android:autoSizeTextType="uniform"
+        android:autoSizeMinTextSize="1sp"
+        android:autoSizeMaxTextSize="120sp"
+        android:autoSizeStepGranularity="1sp"
+        android:text="---" />
+
+    <ImageView
+        android:id="@+id/gtw_arrow"
+        android:layout_width="0dp"
+        android:layout_height="match_parent"
+        android:layout_weight="1"
+        android:layout_marginStart="8dp"
+        android:scaleType="fitCenter"
+        android:contentDescription="Trend" />
+
+</LinearLayout>

--- a/Common/src/main/res/layout/glucose_trend_widget_short.xml
+++ b/Common/src/main/res/layout/glucose_trend_widget_short.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/glucose_trend_widget_root"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="horizontal"
+    android:gravity="center_vertical"
+    android:background="@android:color/transparent"
+    android:paddingStart="4dp"
+    android:paddingEnd="4dp"
+    android:paddingTop="4dp"
+    android:paddingBottom="4dp">
+
+    <TextView
+        android:id="@+id/gtw_glucose"
+        android:layout_width="0dp"
+        android:layout_height="match_parent"
+        android:layout_weight="7"
+        android:gravity="center"
+        android:maxLines="1"
+        android:autoSizeTextType="uniform"
+        android:autoSizeMinTextSize="1sp"
+        android:autoSizeMaxTextSize="96sp"
+        android:autoSizeStepGranularity="1sp"
+        android:text="---" />
+
+    <ImageView
+        android:id="@+id/gtw_arrow"
+        android:layout_width="0dp"
+        android:layout_height="match_parent"
+        android:layout_weight="3"
+        android:layout_marginStart="4dp"
+        android:scaleType="fitCenter"
+        android:contentDescription="Trend" />
+
+</LinearLayout>

--- a/Common/src/main/res/layout/lockscreen_wallpaper_view.xml
+++ b/Common/src/main/res/layout/lockscreen_wallpaper_view.xml
@@ -1,0 +1,111 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+    Lock-screen wallpaper card layout.
+    Inspired by GDH wallpaper.xml + floating_widget.xml.
+
+    Dimensions:
+      500 x 480 dp (inflated/measured off-screen, then drawn to a bitmap).
+
+    Rows:
+      Row 1 (weight 3): glucose value (weight 3) | trend arrow (weight 2)
+      Row 2 (weight 1): elapsed time (left)       | Δ delta (right)
+      Row 3 (weight 2): 3-hour glucose history graph (hidden when not loaded)
+
+    Background: semi-transparent dark rounded rectangle so the user's wallpaper
+    photo shows through around the card  (#88000000 via lockscreen_wallpaper_bg).
+-->
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/lswp_root"
+    android:layout_width="500dp"
+    android:layout_height="480dp"
+    android:orientation="vertical"
+    android:background="@drawable/lockscreen_wallpaper_bg"
+    android:padding="12dp">
+
+    <!-- Row 1: glucose value + trend arrow -->
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:layout_weight="3"
+        android:orientation="horizontal"
+        android:gravity="center_vertical">
+
+        <TextView
+            android:id="@+id/lswp_glucose"
+            android:layout_width="0dp"
+            android:layout_height="match_parent"
+            android:layout_weight="3"
+            android:gravity="center"
+            android:maxLines="1"
+            android:autoSizeTextType="uniform"
+            android:autoSizeMinTextSize="1sp"
+            android:autoSizeMaxTextSize="120sp"
+            android:autoSizeStepGranularity="1sp"
+            android:textStyle="bold"
+            android:text="---"
+            android:textColor="#FFFFFFFF" />
+
+        <ImageView
+            android:id="@+id/lswp_arrow"
+            android:layout_width="0dp"
+            android:layout_height="match_parent"
+            android:layout_weight="2"
+            android:layout_marginStart="6dp"
+            android:scaleType="fitCenter"
+            android:contentDescription="Trend arrow" />
+
+    </LinearLayout>
+
+    <!-- Row 2: time (left) + delta (right) -->
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:layout_weight="1"
+        android:orientation="horizontal"
+        android:gravity="center_vertical">
+
+        <TextView
+            android:id="@+id/lswp_time"
+            android:layout_width="0dp"
+            android:layout_height="match_parent"
+            android:layout_weight="1"
+            android:gravity="center"
+            android:maxLines="1"
+            android:autoSizeTextType="uniform"
+            android:autoSizeMinTextSize="1sp"
+            android:autoSizeMaxTextSize="28sp"
+            android:autoSizeStepGranularity="1sp"
+            android:textStyle="bold"
+            android:text="\uD83D\uDD52 0 min"
+            android:textColor="#FFFFFFFF" />
+
+        <TextView
+            android:id="@+id/lswp_delta"
+            android:layout_width="0dp"
+            android:layout_height="match_parent"
+            android:layout_weight="1"
+            android:gravity="center"
+            android:maxLines="1"
+            android:autoSizeTextType="uniform"
+            android:autoSizeMinTextSize="1sp"
+            android:autoSizeMaxTextSize="28sp"
+            android:autoSizeStepGranularity="1sp"
+            android:textStyle="bold"
+            android:text="\u0394 +0.0"
+            android:textColor="#FFFFFFFF" />
+
+    </LinearLayout>
+
+    <!-- Row 3: 3-hour glucose history graph (shown only when native lib loaded) -->
+    <ImageView
+        android:id="@+id/lswp_graph"
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:layout_weight="2"
+        android:layout_marginTop="6dp"
+        android:scaleType="fitXY"
+        android:adjustViewBounds="false"
+        android:visibility="gone"
+        android:contentDescription="@string/glucose_graph_desc" />
+
+</LinearLayout>

--- a/Common/src/main/res/layout/notification_glucose_permanent.xml
+++ b/Common/src/main/res/layout/notification_glucose_permanent.xml
@@ -1,0 +1,90 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+    Persistent glucose notification layout — always visible on lock screen.
+    Shows (collapsed): large glucose value (range-coloured) | trend arrow | Δ delta | elapsed time.
+    Shows (expanded / big content view): same top row + 3-hour glucose history graph below.
+-->
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="vertical">
+
+    <!-- ── Top row: value | arrow | delta + time ── -->
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        android:gravity="center_vertical"
+        android:paddingTop="4dp"
+        android:paddingBottom="4dp">
+
+        <!-- Large glucose value -->
+        <TextView
+            android:id="@+id/pn_glucose"
+            android:layout_width="wrap_content"
+            android:layout_height="48dp"
+            android:gravity="center_vertical"
+            android:autoSizeTextType="uniform"
+            android:autoSizeMinTextSize="8sp"
+            android:autoSizeMaxTextSize="40sp"
+            android:autoSizeStepGranularity="1sp"
+            android:maxLines="1"
+            android:minWidth="48dp"
+            android:textStyle="bold"
+            android:shadowColor="#000000"
+            android:shadowRadius="3"
+            android:text="---" />
+
+        <!-- Trend arrow bitmap -->
+        <ImageView
+            android:id="@+id/pn_arrow"
+            android:layout_width="44dp"
+            android:layout_height="44dp"
+            android:scaleType="fitCenter"
+            android:adjustViewBounds="true"
+            android:contentDescription="@string/trend_arrow_desc" />
+
+        <!-- Right column: delta + elapsed time stacked -->
+        <LinearLayout
+            android:layout_width="wrap_content"
+            android:layout_height="match_parent"
+            android:orientation="vertical"
+            android:gravity="center_vertical"
+            android:layout_marginStart="6dp">
+
+            <TextView
+                android:id="@+id/pn_delta"
+                android:layout_width="wrap_content"
+                android:layout_height="0dp"
+                android:layout_weight="1"
+                android:gravity="center_vertical"
+                android:maxLines="1"
+                android:textSize="16sp"
+                android:textStyle="bold"
+                android:text="\u0394 --" />
+
+            <TextView
+                android:id="@+id/pn_time"
+                android:layout_width="wrap_content"
+                android:layout_height="0dp"
+                android:layout_weight="1"
+                android:gravity="center_vertical"
+                android:maxLines="1"
+                android:textSize="14sp"
+                android:text="-- min" />
+
+        </LinearLayout>
+
+    </LinearLayout>
+
+    <!-- ── Graph row: 3-hour glucose history (shown only in the big/expanded view) ── -->
+    <ImageView
+        android:id="@+id/pn_graph"
+        android:layout_width="match_parent"
+        android:layout_height="100dp"
+        android:scaleType="fitXY"
+        android:adjustViewBounds="false"
+        android:visibility="gone"
+        android:contentDescription="@string/glucose_graph_desc" />
+
+</LinearLayout>

--- a/Common/src/main/res/values-be/strings.xml
+++ b/Common/src/main/res/values-be/strings.xml
@@ -346,4 +346,36 @@
  <string name="phone">тэлефон</string>
  <string name="connectionl"></string>
 
+    <string name="lockscreen_wallpaper">Шпалеры экрана блакіроўкі</string>
+    <string name="alarm_lockscreen">Будзільнік на экране блакіроўкі</string>
+    <string name="widget_bg_alpha_title">Фон віджэта</string>
+    <string name="widget_bg_alpha_none">Няма (празрысты)</string>
+    <string name="widget_bg_alpha_light">Светлы (25%)</string>
+    <string name="widget_bg_alpha_medium">Сярэдні (50%)</string>
+    <string name="widget_bg_alpha_dark">Цёмны (75%)</string>
+    <string name="snooze_cancel">Адмяніць адкладанне</string>
+    <string name="snooze_30">30 хвілін</string>
+    <string name="snooze_60">60 хвілін</string>
+    <string name="snooze_90">90 хвілін</string>
+    <string name="snooze_120">120 хвілін</string>
+    <string name="snooze_max_3">Максімум 3 доўгасці дазволена</string>
+    <string name="snooze_cancelled">Адкладанне адменена</string>
+    <string name="snooze_not_active">Няма актыўнага адкладання</string>
+    <string name="snooze_buttons_title">Кнопкі адкладання</string>
+    <string name="snooze_buttons_summary">Выберыце да 3 доўгасцей адкладання для адлюстравання на экране будзільніка</string>
+    <string name="notif_snooze_label">Адкласці</string>
+    <string name="notif_snooze_min">%1$d хв</string>
+    <string name="notif_stop_alarm">Адкласці трывогу</string>
+    <string name="alarm_fullscreen_grant">Выдаць дазвол на паўнаэкранны будільнік</string>
+
+    <string name="lockscreen_dismiss">Закрыць будзільнік</string>
+    <string name="lockscreen_dismiss_hold">Утрымлівайце для закрыцця</string>
+    <string name="lockscreen_snooze">Адкласці</string>
+    <string name="lockscreen_snoozed_until">Адкладзена да</string>
+    <string name="widget_glucose_chart">Графік глюкозы</string>
+    <string name="permanent_glucose_notif">Глюкоза на экране блакіроўкі</string>
+    <string name="permanent_notif_channel_name">Статус глюкозы</string>
+    <string name="permanent_notif_channel_desc">Заўсёды бачнае значэнне глюкозы, трэнд і час на экране блакіроўкі</string>
+    <string name="trend_arrow_desc">Стрэлка трэнду</string>
+    <string name="glucose_graph_desc">Графік гісторыі глюкозы</string>
 </resources>

--- a/Common/src/main/res/values-de/strings.xml
+++ b/Common/src/main/res/values-de/strings.xml
@@ -482,6 +482,38 @@
 <string name="dark">Dunkel</string>
 <string name="apply">Anwenden</string>
 <string name="theme">Design</string>
+    <string name="lockscreen_wallpaper">Sperrbildschirm-Hintergrundbild</string>
+    <string name="alarm_lockscreen">Alarm auf Sperrbildschirm</string>
+    <string name="widget_bg_alpha_title">Widget-Hintergrund</string>
+    <string name="widget_bg_alpha_none">Keiner (transparent)</string>
+    <string name="widget_bg_alpha_light">Hell (25%)</string>
+    <string name="widget_bg_alpha_medium">Mittel (50%)</string>
+    <string name="widget_bg_alpha_dark">Dunkel (75%)</string>
+    <string name="snooze_cancel">Schlummern abbrechen</string>
+    <string name="snooze_30">30 Minuten</string>
+    <string name="snooze_60">60 Minuten</string>
+    <string name="snooze_90">90 Minuten</string>
+    <string name="snooze_120">120 Minuten</string>
+    <string name="snooze_max_3">Maximal 3 Dauern erlaubt</string>
+    <string name="snooze_cancelled">Schlummern abgebrochen</string>
+    <string name="snooze_not_active">Kein aktives Schlummern</string>
+    <string name="snooze_buttons_title">Schlummertasten</string>
+    <string name="snooze_buttons_summary">Wähle bis zu 3 Schlummerdauern für den Alarmbildschirm</string>
+    <string name="notif_snooze_label">Schlummern</string>
+    <string name="notif_snooze_min">%1$d Min.</string>
+    <string name="notif_stop_alarm">Alarm stoppen</string>
+    <string name="alarm_fullscreen_grant">Vollbildberechtigung für Alarm erteilen</string>
+
+    <string name="lockscreen_dismiss">Alarm schließen</string>
+    <string name="lockscreen_dismiss_hold">Gedrückt halten zum Schließen</string>
+    <string name="lockscreen_snooze">Schlummern</string>
+    <string name="lockscreen_snoozed_until">Schlummern bis</string>
+    <string name="widget_glucose_chart">Glukose-Diagramm</string>
+    <string name="permanent_glucose_notif">Glukose auf Sperrbildschirm</string>
+    <string name="permanent_notif_channel_name">Glukosestatus</string>
+    <string name="permanent_notif_channel_desc">Immer sichtbarer Glukosewert, Trend und Zeit auf dem Sperrbildschirm</string>
+    <string name="trend_arrow_desc">Trendpfeil</string>
+    <string name="glucose_graph_desc">Glukose-Verlaufsgraph</string>
 </resources>
 
 

--- a/Common/src/main/res/values-es/strings.xml
+++ b/Common/src/main/res/values-es/strings.xml
@@ -448,4 +448,36 @@
     <string name="failed">falló</string>
     <string name="successful">exitoso</string>
     <string name="use">Activar</string>
+    <string name="lockscreen_wallpaper">Fondo de pantalla de bloqueo</string>
+    <string name="alarm_lockscreen">Alarma en pantalla de bloqueo</string>
+    <string name="widget_bg_alpha_title">Fondo del widget</string>
+    <string name="widget_bg_alpha_none">Ninguno (transparente)</string>
+    <string name="widget_bg_alpha_light">Claro (25%)</string>
+    <string name="widget_bg_alpha_medium">Medio (50%)</string>
+    <string name="widget_bg_alpha_dark">Oscuro (75%)</string>
+    <string name="snooze_cancel">Cancelar posponer</string>
+    <string name="snooze_30">30 minutos</string>
+    <string name="snooze_60">60 minutos</string>
+    <string name="snooze_90">90 minutos</string>
+    <string name="snooze_120">120 minutos</string>
+    <string name="snooze_max_3">Máximo 3 duraciones permitidas</string>
+    <string name="snooze_cancelled">Posponer cancelado</string>
+    <string name="snooze_not_active">Sin posponer activo</string>
+    <string name="snooze_buttons_title">Botones de posponer</string>
+    <string name="snooze_buttons_summary">Elige hasta 3 duraciones de posponer para mostrar en la pantalla de alarma</string>
+    <string name="notif_snooze_label">Posponer</string>
+    <string name="notif_snooze_min">%1$d min</string>
+    <string name="notif_stop_alarm">Detener alarma</string>
+    <string name="alarm_fullscreen_grant">Conceder permiso de alarma en pantalla completa</string>
+
+    <string name="lockscreen_dismiss">Descartar alarma</string>
+    <string name="lockscreen_dismiss_hold">Mantén para descartar</string>
+    <string name="lockscreen_snooze">Posponer</string>
+    <string name="lockscreen_snoozed_until">Pospuesto hasta</string>
+    <string name="widget_glucose_chart">Gráfico de glucosa</string>
+    <string name="permanent_glucose_notif">Glucosa en pantalla de bloqueo</string>
+    <string name="permanent_notif_channel_name">Estado de glucosa</string>
+    <string name="permanent_notif_channel_desc">Valor de glucosa, tendencia y tiempo siempre visibles en la pantalla de bloqueo</string>
+    <string name="trend_arrow_desc">Flecha de tendencia</string>
+    <string name="glucose_graph_desc">Gráfico de historial de glucosa</string>
 </resources>

--- a/Common/src/main/res/values-fr/strings.xml
+++ b/Common/src/main/res/values-fr/strings.xml
@@ -297,4 +297,36 @@
 <string name="enternums">Enter amounts on</string>
 <string name="directsensor">Connexion directe capteur-</string>
 <string name="connectionl"></string>
+    <string name="lockscreen_wallpaper">Fond d\'écran de verrouillage</string>
+    <string name="alarm_lockscreen">Alarme sur écran de verrouillage</string>
+    <string name="widget_bg_alpha_title">Arrière-plan du widget</string>
+    <string name="widget_bg_alpha_none">Aucun (transparent)</string>
+    <string name="widget_bg_alpha_light">Clair (25%)</string>
+    <string name="widget_bg_alpha_medium">Moyen (50%)</string>
+    <string name="widget_bg_alpha_dark">Sombre (75%)</string>
+    <string name="snooze_cancel">Annuler la mise en veille</string>
+    <string name="snooze_30">30 minutes</string>
+    <string name="snooze_60">60 minutes</string>
+    <string name="snooze_90">90 minutes</string>
+    <string name="snooze_120">120 minutes</string>
+    <string name="snooze_max_3">Maximum 3 durées autorisées</string>
+    <string name="snooze_cancelled">Mise en veille annulée</string>
+    <string name="snooze_not_active">Aucune mise en veille active</string>
+    <string name="snooze_buttons_title">Boutons de mise en veille</string>
+    <string name="snooze_buttons_summary">Choisissez jusqu\'à 3 durées de mise en veille à afficher sur l\'écran d\'alarme</string>
+    <string name="notif_snooze_label">Veille</string>
+    <string name="notif_snooze_min">%1$d min</string>
+    <string name="notif_stop_alarm">Arrêter l\'alarme</string>
+    <string name="alarm_fullscreen_grant">Autoriser l\'alarme plein écran</string>
+
+    <string name="lockscreen_dismiss">Ignorer l\'alarme</string>
+    <string name="lockscreen_dismiss_hold">Maintenir pour ignorer</string>
+    <string name="lockscreen_snooze">Mettre en veille</string>
+    <string name="lockscreen_snoozed_until">En veille jusqu\'à</string>
+    <string name="widget_glucose_chart">Graphique glucose</string>
+    <string name="permanent_glucose_notif">Glucose sur écran verrouillé</string>
+    <string name="permanent_notif_channel_name">Statut glucose</string>
+    <string name="permanent_notif_channel_desc">Valeur de glucose, tendance et heure toujours visibles sur l\'écran verrouillé</string>
+    <string name="trend_arrow_desc">Flèche de tendance</string>
+    <string name="glucose_graph_desc">Graphique d\'historique de glycémie</string>
 </resources>

--- a/Common/src/main/res/values-hi/strings.xml
+++ b/Common/src/main/res/values-hi/strings.xml
@@ -486,4 +486,36 @@
     <string name="nohistoryvalues">कोई इतिहास मान नहीं</string>
     <string name="jugglucoupdate">समय अपडेट करें</string>
 
+    <string name="lockscreen_wallpaper">लॉक स्क्रीन वॉलपेपर</string>
+    <string name="alarm_lockscreen">लॉक स्क्रीन पर अलार्म</string>
+    <string name="widget_bg_alpha_title">विजेट पृष्ठभूमि</string>
+    <string name="widget_bg_alpha_none">कोई नहीं (पारदर्शी)</string>
+    <string name="widget_bg_alpha_light">हल्का (25%)</string>
+    <string name="widget_bg_alpha_medium">मध्यम (50%)</string>
+    <string name="widget_bg_alpha_dark">गहरा (75%)</string>
+    <string name="snooze_cancel">स्नूज़ रद्द करें</string>
+    <string name="snooze_30">30 मिनट</string>
+    <string name="snooze_60">60 मिनट</string>
+    <string name="snooze_90">90 मिनट</string>
+    <string name="snooze_120">120 मिनट</string>
+    <string name="snooze_max_3">अधिकतम 3 अवधि अनुमत</string>
+    <string name="snooze_cancelled">स्नूज़ रद्द किया गया</string>
+    <string name="snooze_not_active">कोई सक्रिय स्नूज़ नहीं</string>
+    <string name="snooze_buttons_title">स्नूज़ बटन</string>
+    <string name="snooze_buttons_summary">अलार्म स्क्रीन पर दिखाने के लिए 3 तक स्नूज़ अवधि चुनें</string>
+    <string name="notif_snooze_label">स्नूज़</string>
+    <string name="notif_snooze_min">%1$d मि.</string>
+    <string name="notif_stop_alarm">अलार्म बंद करें</string>
+    <string name="alarm_fullscreen_grant">पूर्ण-स्क्रीन अलार्म अनुमति दें</string>
+
+    <string name="lockscreen_dismiss">अलार्म बंद करें</string>
+    <string name="lockscreen_dismiss_hold">बंद करने के लिए दबाए रखें</string>
+    <string name="lockscreen_snooze">स्नूज़</string>
+    <string name="lockscreen_snoozed_until">तक स्नूज़ किया</string>
+    <string name="widget_glucose_chart">ग्लूकोज़ चार्ट</string>
+    <string name="permanent_glucose_notif">लॉक स्क्रीन पर ग्लूकोज़</string>
+    <string name="permanent_notif_channel_name">ग्लूकोज़ स्थिति</string>
+    <string name="permanent_notif_channel_desc">लॉक स्क्रीन पर हमेशा दिखने वाला ग्लूकोज़ मान, ट्रेंड और समय</string>
+    <string name="trend_arrow_desc">ट्रेंड तीर</string>
+    <string name="glucose_graph_desc">ग्लूकोज इतिहास ग्राफ</string>
 </resources>

--- a/Common/src/main/res/values-it/strings.xml
+++ b/Common/src/main/res/values-it/strings.xml
@@ -493,4 +493,36 @@
      <string name="emailnotused">La combinazione email-password non viene usata e non sarà salvata.</string>
     <string name="connecttoserver">Connessione al server…</string>
     <string name="retrievefailed">Recupero account id fallito</string>
+    <string name="lockscreen_wallpaper">Sfondo schermata di blocco</string>
+    <string name="alarm_lockscreen">Allarme su schermata di blocco</string>
+    <string name="widget_bg_alpha_title">Sfondo widget</string>
+    <string name="widget_bg_alpha_none">Nessuno (trasparente)</string>
+    <string name="widget_bg_alpha_light">Chiaro (25%)</string>
+    <string name="widget_bg_alpha_medium">Medio (50%)</string>
+    <string name="widget_bg_alpha_dark">Scuro (75%)</string>
+    <string name="snooze_cancel">Annulla posticipo</string>
+    <string name="snooze_30">30 minuti</string>
+    <string name="snooze_60">60 minuti</string>
+    <string name="snooze_90">90 minuti</string>
+    <string name="snooze_120">120 minuti</string>
+    <string name="snooze_max_3">Massimo 3 durate consentite</string>
+    <string name="snooze_cancelled">Posticipo annullato</string>
+    <string name="snooze_not_active">Nessun posticipo attivo</string>
+    <string name="snooze_buttons_title">Pulsanti posticipo</string>
+    <string name="snooze_buttons_summary">Scegli fino a 3 durate di posticipo da mostrare nella schermata di allarme</string>
+    <string name="notif_snooze_label">Posticipa</string>
+    <string name="notif_snooze_min">%1$d min</string>
+    <string name="notif_stop_alarm">Ferma allarme</string>
+    <string name="alarm_fullscreen_grant">Concedi permesso allarme a schermo intero</string>
+
+    <string name="lockscreen_dismiss">Ignora allarme</string>
+    <string name="lockscreen_dismiss_hold">Tieni premuto per ignorare</string>
+    <string name="lockscreen_snooze">Posticipa</string>
+    <string name="lockscreen_snoozed_until">Posticipato fino a</string>
+    <string name="widget_glucose_chart">Grafico glucosio</string>
+    <string name="permanent_glucose_notif">Glucosio sulla schermata di blocco</string>
+    <string name="permanent_notif_channel_name">Stato glucosio</string>
+    <string name="permanent_notif_channel_desc">Valore glicemico, tendenza e ora sempre visibili sulla schermata di blocco</string>
+    <string name="trend_arrow_desc">Freccia di tendenza</string>
+    <string name="glucose_graph_desc">Grafico storico della glicemia</string>
 </resources>

--- a/Common/src/main/res/values-ja/strings.xml
+++ b/Common/src/main/res/values-ja/strings.xml
@@ -488,4 +488,36 @@
     <string name="jugglucoupdate">更新時刻</string>
 
 
+    <string name="lockscreen_wallpaper">ロック画面の壁紙</string>
+    <string name="alarm_lockscreen">ロック画面のアラーム</string>
+    <string name="widget_bg_alpha_title">ウィジェット背景</string>
+    <string name="widget_bg_alpha_none">なし（透明）</string>
+    <string name="widget_bg_alpha_light">薄い（25%）</string>
+    <string name="widget_bg_alpha_medium">中間（50%）</string>
+    <string name="widget_bg_alpha_dark">暗い（75%）</string>
+    <string name="snooze_cancel">スヌーズをキャンセル</string>
+    <string name="snooze_30">30分</string>
+    <string name="snooze_60">60分</string>
+    <string name="snooze_90">90分</string>
+    <string name="snooze_120">120分</string>
+    <string name="snooze_max_3">最大3つの期間が許可されます</string>
+    <string name="snooze_cancelled">スヌーズがキャンセルされました</string>
+    <string name="snooze_not_active">アクティブなスヌーズはありません</string>
+    <string name="snooze_buttons_title">スヌーズボタン</string>
+    <string name="snooze_buttons_summary">アラーム画面に表示するスヌーズ期間を最大3つ選択してください</string>
+    <string name="notif_snooze_label">スヌーズ</string>
+    <string name="notif_snooze_min">%1$d分</string>
+    <string name="notif_stop_alarm">アラームを止める</string>
+    <string name="alarm_fullscreen_grant">全画面アラームの許可を付与</string>
+
+    <string name="lockscreen_dismiss">アラームを閉じる</string>
+    <string name="lockscreen_dismiss_hold">押し続けて閉じる</string>
+    <string name="lockscreen_snooze">スヌーズ</string>
+    <string name="lockscreen_snoozed_until">までスヌーズ</string>
+    <string name="widget_glucose_chart">グルコースチャート</string>
+    <string name="permanent_glucose_notif">ロック画面に血糖値を表示</string>
+    <string name="permanent_notif_channel_name">血糖値状態</string>
+    <string name="permanent_notif_channel_desc">ロック画面に血糖値・トレンド・経過時間を常時表示</string>
+    <string name="trend_arrow_desc">トレンド矢印</string>
+    <string name="glucose_graph_desc">血糖値履歴グラフ</string>
 </resources>

--- a/Common/src/main/res/values-nl/strings.xml
+++ b/Common/src/main/res/values-nl/strings.xml
@@ -467,6 +467,37 @@
 <string name="dark">Donker</string>
 <string name="apply">Toepassen</string>
 <string name="theme">Thema</string>
+    <string name="lockscreen_wallpaper">Achtergrond vergrendelscherm</string>
+    <string name="alarm_lockscreen">Alarm op vergrendelscherm</string>
+    <string name="widget_bg_alpha_title">Widget-achtergrond</string>
+    <string name="widget_bg_alpha_none">Geen (transparant)</string>
+    <string name="widget_bg_alpha_light">Licht (25%)</string>
+    <string name="widget_bg_alpha_medium">Gemiddeld (50%)</string>
+    <string name="widget_bg_alpha_dark">Donker (75%)</string>
+    <string name="snooze_cancel">Sluimeren annuleren</string>
+    <string name="snooze_30">30 minuten</string>
+    <string name="snooze_60">60 minuten</string>
+    <string name="snooze_90">90 minuten</string>
+    <string name="snooze_120">120 minuten</string>
+    <string name="snooze_max_3">Maximaal 3 duren toegestaan</string>
+    <string name="snooze_cancelled">Sluimeren geannuleerd</string>
+    <string name="snooze_not_active">Geen actief sluimeren</string>
+    <string name="snooze_buttons_title">Sluimerknoppen</string>
+    <string name="snooze_buttons_summary">Kies tot 3 sluimerduren voor het alarmscherm</string>
+    <string name="notif_snooze_label">Sluimeren</string>
+    <string name="notif_snooze_min">%1$d min</string>
+    <string name="notif_stop_alarm">Alarm stoppen</string>
+    <string name="alarm_fullscreen_grant">Volledige scherm alarmmachtiging verlenen</string>
 
+    <string name="lockscreen_dismiss">Alarm sluiten</string>
+    <string name="lockscreen_dismiss_hold">Ingedrukt houden om te sluiten</string>
+    <string name="lockscreen_snooze">Sluimeren</string>
+    <string name="lockscreen_snoozed_until">Gesluimerd tot</string>
+    <string name="widget_glucose_chart">Glucose grafiek</string>
+    <string name="permanent_glucose_notif">Glucose op vergrendelscherm</string>
+    <string name="permanent_notif_channel_name">Glucosestatus</string>
+    <string name="permanent_notif_channel_desc">Altijd zichtbare glucosewaarde, trend en tijd op het vergrendelscherm</string>
+    <string name="trend_arrow_desc">Trendpijl</string>
+    <string name="glucose_graph_desc">Glucosegeschiedenisgraaf</string>
 </resources>
 

--- a/Common/src/main/res/values-pl/strings.xml
+++ b/Common/src/main/res/values-pl/strings.xml
@@ -447,4 +447,36 @@
 <string name="enternums">Wpisuj wartości na</string>
 <string name="connectionl">połączenie</string>
 <string name="disconnectsensor">Błąd</string>
+    <string name="lockscreen_wallpaper">Tapeta ekranu blokady</string>
+    <string name="alarm_lockscreen">Alarm na ekranie blokady</string>
+    <string name="widget_bg_alpha_title">Tło widżetu</string>
+    <string name="widget_bg_alpha_none">Brak (przezroczyste)</string>
+    <string name="widget_bg_alpha_light">Jasne (25%)</string>
+    <string name="widget_bg_alpha_medium">Średnie (50%)</string>
+    <string name="widget_bg_alpha_dark">Ciemne (75%)</string>
+    <string name="snooze_cancel">Anuluj drzemkę</string>
+    <string name="snooze_30">30 minut</string>
+    <string name="snooze_60">60 minut</string>
+    <string name="snooze_90">90 minut</string>
+    <string name="snooze_120">120 minut</string>
+    <string name="snooze_max_3">Maksymalnie 3 czasy dozwolone</string>
+    <string name="snooze_cancelled">Drzemka anulowana</string>
+    <string name="snooze_not_active">Brak aktywnej drzemki</string>
+    <string name="snooze_buttons_title">Przyciski drzemki</string>
+    <string name="snooze_buttons_summary">Wybierz do 3 czasów drzemki do wyświetlenia na ekranie alarmu</string>
+    <string name="notif_snooze_label">Drzemka</string>
+    <string name="notif_snooze_min">%1$d min</string>
+    <string name="notif_stop_alarm">Zatrzymaj alarm</string>
+    <string name="alarm_fullscreen_grant">Przyznaj uprawnienia do alarmu pełnoekranowego</string>
+
+    <string name="lockscreen_dismiss">Odrzuć alarm</string>
+    <string name="lockscreen_dismiss_hold">Przytrzymaj, aby odrzucić</string>
+    <string name="lockscreen_snooze">Drzemka</string>
+    <string name="lockscreen_snoozed_until">Drzemka do</string>
+    <string name="widget_glucose_chart">Wykres glukozy</string>
+    <string name="permanent_glucose_notif">Glukoza na ekranie blokady</string>
+    <string name="permanent_notif_channel_name">Status glukozy</string>
+    <string name="permanent_notif_channel_desc">Zawsze widoczna wartość glukozy, trend i czas na ekranie blokady</string>
+    <string name="trend_arrow_desc">Strzałka trendu</string>
+    <string name="glucose_graph_desc">Wykres historii glukozy</string>
 </resources>

--- a/Common/src/main/res/values-pt/strings.xml
+++ b/Common/src/main/res/values-pt/strings.xml
@@ -232,6 +232,38 @@
 <string name="phone">telefone</string>
 <string name="directsensor">Conexão direta sensor-</string>
 <string name="connectionl"></string>
+    <string name="lockscreen_wallpaper">Papel de parede da tela de bloqueio</string>
+    <string name="alarm_lockscreen">Alarme na tela de bloqueio</string>
+    <string name="widget_bg_alpha_title">Fundo do widget</string>
+    <string name="widget_bg_alpha_none">Nenhum (transparente)</string>
+    <string name="widget_bg_alpha_light">Claro (25%)</string>
+    <string name="widget_bg_alpha_medium">Médio (50%)</string>
+    <string name="widget_bg_alpha_dark">Escuro (75%)</string>
+    <string name="snooze_cancel">Cancelar soneca</string>
+    <string name="snooze_30">30 minutos</string>
+    <string name="snooze_60">60 minutos</string>
+    <string name="snooze_90">90 minutos</string>
+    <string name="snooze_120">120 minutos</string>
+    <string name="snooze_max_3">Máximo de 3 durações permitidas</string>
+    <string name="snooze_cancelled">Soneca cancelada</string>
+    <string name="snooze_not_active">Sem soneca ativa</string>
+    <string name="snooze_buttons_title">Botões de soneca</string>
+    <string name="snooze_buttons_summary">Escolha até 3 durações de soneca para exibir na tela de alarme</string>
+    <string name="notif_snooze_label">Soneca</string>
+    <string name="notif_snooze_min">%1$d min</string>
+    <string name="notif_stop_alarm">Parar alarme</string>
+    <string name="alarm_fullscreen_grant">Conceder permissão de alarme em tela cheia</string>
+
+    <string name="lockscreen_dismiss">Dispensar alarme</string>
+    <string name="lockscreen_dismiss_hold">Segure para dispensar</string>
+    <string name="lockscreen_snooze">Soneca</string>
+    <string name="lockscreen_snoozed_until">Soneca até</string>
+    <string name="widget_glucose_chart">Gráfico de glicose</string>
+    <string name="permanent_glucose_notif">Glicose na tela de bloqueio</string>
+    <string name="permanent_notif_channel_name">Status de glicose</string>
+    <string name="permanent_notif_channel_desc">Valor de glicose, tendência e tempo sempre visíveis na tela de bloqueio</string>
+    <string name="trend_arrow_desc">Seta de tendência</string>
+    <string name="glucose_graph_desc">Gráfico do histórico de glicose</string>
 </resources>
 
 

--- a/Common/src/main/res/values-ru/strings.xml
+++ b/Common/src/main/res/values-ru/strings.xml
@@ -483,5 +483,37 @@
     <string name="light">Светлая</string>
     <string name="dark">Темная</string>
     <string name="apply">Применить</string>
+    <string name="lockscreen_wallpaper">Обои экрана блокировки</string>
+    <string name="alarm_lockscreen">Будильник на экране блокировки</string>
+    <string name="widget_bg_alpha_title">Фон виджета</string>
+    <string name="widget_bg_alpha_none">Нет (прозрачный)</string>
+    <string name="widget_bg_alpha_light">Светлый (25%)</string>
+    <string name="widget_bg_alpha_medium">Средний (50%)</string>
+    <string name="widget_bg_alpha_dark">Тёмный (75%)</string>
+    <string name="snooze_cancel">Отменить отложить</string>
+    <string name="snooze_30">30 минут</string>
+    <string name="snooze_60">60 минут</string>
+    <string name="snooze_90">90 минут</string>
+    <string name="snooze_120">120 минут</string>
+    <string name="snooze_max_3">Максимум 3 продолжительности разрешено</string>
+    <string name="snooze_cancelled">Отложить отменено</string>
+    <string name="snooze_not_active">Нет активного откладывания</string>
+    <string name="snooze_buttons_title">Кнопки откладывания</string>
+    <string name="snooze_buttons_summary">Выберите до 3 продолжительностей для отображения на экране будильника</string>
+    <string name="notif_snooze_label">Отложить</string>
+    <string name="notif_snooze_min">%1$d мин</string>
+    <string name="notif_stop_alarm">Остановить будильник</string>
+    <string name="alarm_fullscreen_grant">Разрешить полноэкранный будильник</string>
+
+    <string name="lockscreen_dismiss">Закрыть будильник</string>
+    <string name="lockscreen_dismiss_hold">Удерживайте для закрытия</string>
+    <string name="lockscreen_snooze">Отложить</string>
+    <string name="lockscreen_snoozed_until">Отложено до</string>
+    <string name="widget_glucose_chart">График глюкозы</string>
+    <string name="permanent_glucose_notif">Глюкоза на экране блокировки</string>
+    <string name="permanent_notif_channel_name">Статус глюкозы</string>
+    <string name="permanent_notif_channel_desc">Всегда видимое значение глюкозы, тренд и время на экране блокировки</string>
+    <string name="trend_arrow_desc">Стрелка тренда</string>
+    <string name="glucose_graph_desc">График истории глюкозы</string>
 </resources>
 

--- a/Common/src/main/res/values-sv/strings.xml
+++ b/Common/src/main/res/values-sv/strings.xml
@@ -335,4 +335,36 @@
 <string name="watch">klocka</string>
 <string name="directsensor">Direktanslutning mellan sensor och</string>
 <string name="connectionl"></string>
+    <string name="lockscreen_wallpaper">Låsskärmens bakgrundsbild</string>
+    <string name="alarm_lockscreen">Alarm på låsskärmen</string>
+    <string name="widget_bg_alpha_title">Widget-bakgrund</string>
+    <string name="widget_bg_alpha_none">Ingen (genomskinlig)</string>
+    <string name="widget_bg_alpha_light">Ljus (25%)</string>
+    <string name="widget_bg_alpha_medium">Mellannivå (50%)</string>
+    <string name="widget_bg_alpha_dark">Mörk (75%)</string>
+    <string name="snooze_cancel">Avbryt snooze</string>
+    <string name="snooze_30">30 minuter</string>
+    <string name="snooze_60">60 minuter</string>
+    <string name="snooze_90">90 minuter</string>
+    <string name="snooze_120">120 minuter</string>
+    <string name="snooze_max_3">Maximalt 3 varaktigheter tillåtna</string>
+    <string name="snooze_cancelled">Snooze avbruten</string>
+    <string name="snooze_not_active">Ingen aktiv snooze</string>
+    <string name="snooze_buttons_title">Snooze-knappar</string>
+    <string name="snooze_buttons_summary">Välj upp till 3 snooze-varaktigheter att visa på larmskärmen</string>
+    <string name="notif_snooze_label">Snooze</string>
+    <string name="notif_snooze_min">%1$d min</string>
+    <string name="notif_stop_alarm">Stoppa larm</string>
+    <string name="alarm_fullscreen_grant">Bevilja helskärmslarmsbehörighet</string>
+
+    <string name="lockscreen_dismiss">Stäng larm</string>
+    <string name="lockscreen_dismiss_hold">Håll in för att stänga</string>
+    <string name="lockscreen_snooze">Snooze</string>
+    <string name="lockscreen_snoozed_until">Snooze till</string>
+    <string name="widget_glucose_chart">Glukosdiagram</string>
+    <string name="permanent_glucose_notif">Glukos på låsskärm</string>
+    <string name="permanent_notif_channel_name">Glukosstatus</string>
+    <string name="permanent_notif_channel_desc">Alltid synligt glukosvärde, trend och tid på låsskärmen</string>
+    <string name="trend_arrow_desc">Trendpil</string>
+    <string name="glucose_graph_desc">Graf över glukoshistorik</string>
 </resources>

--- a/Common/src/main/res/values-tr/strings.xml
+++ b/Common/src/main/res/values-tr/strings.xml
@@ -384,4 +384,36 @@
  <string name="phone">telefon</string>
  <string name="directsensor">Doğrudan sensör-</string>
 <string name="connectionl">bağlantısı</string>
+    <string name="lockscreen_wallpaper">Kilit ekranı duvar kağıdı</string>
+    <string name="alarm_lockscreen">Kilit ekranında alarm</string>
+    <string name="widget_bg_alpha_title">Widget arka planı</string>
+    <string name="widget_bg_alpha_none">Yok (şeffaf)</string>
+    <string name="widget_bg_alpha_light">Açık (25%)</string>
+    <string name="widget_bg_alpha_medium">Orta (50%)</string>
+    <string name="widget_bg_alpha_dark">Koyu (75%)</string>
+    <string name="snooze_cancel">Ertelemeyi iptal et</string>
+    <string name="snooze_30">30 dakika</string>
+    <string name="snooze_60">60 dakika</string>
+    <string name="snooze_90">90 dakika</string>
+    <string name="snooze_120">120 dakika</string>
+    <string name="snooze_max_3">En fazla 3 süre izin verilir</string>
+    <string name="snooze_cancelled">Erteleme iptal edildi</string>
+    <string name="snooze_not_active">Aktif erteleme yok</string>
+    <string name="snooze_buttons_title">Erteleme düğmeleri</string>
+    <string name="snooze_buttons_summary">Alarm ekranında gösterilecek 3\'e kadar erteleme süresi seçin</string>
+    <string name="notif_snooze_label">Ertele</string>
+    <string name="notif_snooze_min">%1$d dak</string>
+    <string name="notif_stop_alarm">Alarmı durdur</string>
+    <string name="alarm_fullscreen_grant">Tam ekran alarm izni ver</string>
+
+    <string name="lockscreen_dismiss">Alarmı kapat</string>
+    <string name="lockscreen_dismiss_hold">Kapatmak için basılı tut</string>
+    <string name="lockscreen_snooze">Ertele</string>
+    <string name="lockscreen_snoozed_until">Ertelendi:</string>
+    <string name="widget_glucose_chart">Glikoz Grafiği</string>
+    <string name="permanent_glucose_notif">Glikoz kilit ekranında</string>
+    <string name="permanent_notif_channel_name">Glikoz durumu</string>
+    <string name="permanent_notif_channel_desc">Kilit ekranında her zaman görünür glikoz değeri, trend ve zaman</string>
+    <string name="trend_arrow_desc">Trend oku</string>
+    <string name="glucose_graph_desc">Glikoz geçmiş grafiği</string>
 </resources>

--- a/Common/src/main/res/values-uk/strings.xml
+++ b/Common/src/main/res/values-uk/strings.xml
@@ -349,4 +349,36 @@
 <string name="watch">годинника</string>
 <string name="directsensor">Пряме підкл. датчика до</string>
 <string name="connectionl"></string>
+    <string name="lockscreen_wallpaper">Шпалери екрана блокування</string>
+    <string name="alarm_lockscreen">Будильник на екрані блокування</string>
+    <string name="widget_bg_alpha_title">Фон віджета</string>
+    <string name="widget_bg_alpha_none">Немає (прозорий)</string>
+    <string name="widget_bg_alpha_light">Світлий (25%)</string>
+    <string name="widget_bg_alpha_medium">Середній (50%)</string>
+    <string name="widget_bg_alpha_dark">Темний (75%)</string>
+    <string name="snooze_cancel">Скасувати відкладення</string>
+    <string name="snooze_30">30 хвилин</string>
+    <string name="snooze_60">60 хвилин</string>
+    <string name="snooze_90">90 хвилин</string>
+    <string name="snooze_120">120 хвилин</string>
+    <string name="snooze_max_3">Максимум 3 тривалості дозволено</string>
+    <string name="snooze_cancelled">Відкладення скасовано</string>
+    <string name="snooze_not_active">Немає активного відкладення</string>
+    <string name="snooze_buttons_title">Кнопки відкладення</string>
+    <string name="snooze_buttons_summary">Виберіть до 3 тривалостей відкладення для відображення на екрані будильника</string>
+    <string name="notif_snooze_label">Відкласти</string>
+    <string name="notif_snooze_min">%1$d хв</string>
+    <string name="notif_stop_alarm">Зупинити будильник</string>
+    <string name="alarm_fullscreen_grant">Надати дозвіл на повноекранний будильник</string>
+
+    <string name="lockscreen_dismiss">Закрити будильник</string>
+    <string name="lockscreen_dismiss_hold">Утримуйте для закриття</string>
+    <string name="lockscreen_snooze">Відкласти</string>
+    <string name="lockscreen_snoozed_until">Відкладено до</string>
+    <string name="widget_glucose_chart">Графік глюкози</string>
+    <string name="permanent_glucose_notif">Глюкоза на екрані блокування</string>
+    <string name="permanent_notif_channel_name">Статус глюкози</string>
+    <string name="permanent_notif_channel_desc">Завжди видиме значення глюкози, тренд і час на екрані блокування</string>
+    <string name="trend_arrow_desc">Стрілка тренду</string>
+    <string name="glucose_graph_desc">Графік історії глюкози</string>
 </resources>

--- a/Common/src/main/res/values-uz/strings.xml
+++ b/Common/src/main/res/values-uz/strings.xml
@@ -465,4 +465,36 @@ Endi transmitter data matrixini skanerlang."</string>
     <string name="messagewebserverneed">Veb-serverni faollashtirish uchun chap menyu-&gt;Sozlamalar-&gt;Ma\'lumot almashish-&gt;Veb-server ga o\'ting</string>
     <string name="nostreamvalues">Oqim qiymatlari yo\'q</string>
     <string name="nohistoryvalues">Tarix qiymatlari yo\'q</string>
+    <string name="lockscreen_wallpaper">Qulf ekrani foni</string>
+    <string name="alarm_lockscreen">Qulf ekranida signal</string>
+    <string name="widget_bg_alpha_title">Vidjet foni</string>
+    <string name="widget_bg_alpha_none">Yo\'q (shaffof)</string>
+    <string name="widget_bg_alpha_light">Ochiq (25%)</string>
+    <string name="widget_bg_alpha_medium">O\'rta (50%)</string>
+    <string name="widget_bg_alpha_dark">To\'q (75%)</string>
+    <string name="snooze_cancel">Snouzni bekor qilish</string>
+    <string name="snooze_30">30 daqiqa</string>
+    <string name="snooze_60">60 daqiqa</string>
+    <string name="snooze_90">90 daqiqa</string>
+    <string name="snooze_120">120 daqiqa</string>
+    <string name="snooze_max_3">Maksimal 3 ta muddat ruxsat etiladi</string>
+    <string name="snooze_cancelled">Snouz bekor qilindi</string>
+    <string name="snooze_not_active">Faol snouz yo\'q</string>
+    <string name="snooze_buttons_title">Snouz tugmalari</string>
+    <string name="snooze_buttons_summary">Signal ekranida ko\'rsatish uchun 3 tagacha snouz muddatini tanlang</string>
+    <string name="notif_snooze_label">Snouz</string>
+    <string name="notif_snooze_min">%1$d daq</string>
+    <string name="notif_stop_alarm">Signalni to\'xtatish</string>
+    <string name="alarm_fullscreen_grant">To\'liq ekran signal ruxsatini berish</string>
+
+    <string name="lockscreen_dismiss">Signalni yopish</string>
+    <string name="lockscreen_dismiss_hold">Yopish uchun ushlab turing</string>
+    <string name="lockscreen_snooze">Snouz</string>
+    <string name="lockscreen_snoozed_until">gacha snouz</string>
+    <string name="widget_glucose_chart">Glyukoza grafigi</string>
+    <string name="permanent_glucose_notif">Glyukoza qulf ekranida</string>
+    <string name="permanent_notif_channel_name">Glyukoza holati</string>
+    <string name="permanent_notif_channel_desc">Qulf ekranida doimo ko\'rinadigan glyukoza qiymati, trend va vaqt</string>
+    <string name="trend_arrow_desc">Trend o\'qi</string>
+    <string name="glucose_graph_desc">Glyukoza tarixi grafigi</string>
 </resources>

--- a/Common/src/main/res/values-zh/strings.xml
+++ b/Common/src/main/res/values-zh/strings.xml
@@ -343,4 +343,36 @@
     <string name="watch">手表</string>
     <string name="phone">手机</string>
  <string name="connectionl">直接连接传感器</string>
+    <string name="lockscreen_wallpaper">锁屏壁纸</string>
+    <string name="alarm_lockscreen">锁屏上的警报</string>
+    <string name="widget_bg_alpha_title">小组件背景</string>
+    <string name="widget_bg_alpha_none">无（透明）</string>
+    <string name="widget_bg_alpha_light">浅色（25%）</string>
+    <string name="widget_bg_alpha_medium">中等（50%）</string>
+    <string name="widget_bg_alpha_dark">深色（75%）</string>
+    <string name="snooze_cancel">取消贪睡</string>
+    <string name="snooze_30">30分钟</string>
+    <string name="snooze_60">60分钟</string>
+    <string name="snooze_90">90分钟</string>
+    <string name="snooze_120">120分钟</string>
+    <string name="snooze_max_3">最多允许3个时长</string>
+    <string name="snooze_cancelled">贪睡已取消</string>
+    <string name="snooze_not_active">没有活跃的贪睡</string>
+    <string name="snooze_buttons_title">贪睡按钮</string>
+    <string name="snooze_buttons_summary">选择最多3个贪睡时长显示在警报屏幕上</string>
+    <string name="notif_snooze_label">贪睡</string>
+    <string name="notif_snooze_min">%1$d 分钟</string>
+    <string name="notif_stop_alarm">停止警报</string>
+    <string name="alarm_fullscreen_grant">授予全屏警报权限</string>
+
+    <string name="lockscreen_dismiss">关闭警报</string>
+    <string name="lockscreen_dismiss_hold">长按关闭</string>
+    <string name="lockscreen_snooze">贪睡</string>
+    <string name="lockscreen_snoozed_until">贪睡至</string>
+    <string name="widget_glucose_chart">血糖图表</string>
+    <string name="permanent_glucose_notif">锁屏血糖显示</string>
+    <string name="permanent_notif_channel_name">血糖状态</string>
+    <string name="permanent_notif_channel_desc">锁屏上始终显示血糖值、趋势和时间</string>
+    <string name="trend_arrow_desc">趋势箭头</string>
+    <string name="glucose_graph_desc">血糖历史图表</string>
 </resources>

--- a/Common/src/main/res/values/strings.xml
+++ b/Common/src/main/res/values/strings.xml
@@ -392,6 +392,38 @@
     <string name="autoqr">Auto QR</string>
     
     <string name="googlescan">Google scan</string>
+    <string name="lockscreen_wallpaper">Lock screen wallpaper</string>
+    <string name="alarm_lockscreen">Alarm on lock screen</string>
+    <string name="widget_bg_alpha_title">Widget background</string>
+    <string name="widget_bg_alpha_none">None (transparent)</string>
+    <string name="widget_bg_alpha_light">Light (25%)</string>
+    <string name="widget_bg_alpha_medium">Medium (50%)</string>
+    <string name="widget_bg_alpha_dark">Dark (75%)</string>
+    <string name="snooze_cancel">Cancel snooze</string>
+    <string name="snooze_30">30 minutes</string>
+    <string name="snooze_60">60 minutes</string>
+    <string name="snooze_90">90 minutes</string>
+    <string name="snooze_120">120 minutes</string>
+    <string name="snooze_max_3">Maximum 3 durations allowed</string>
+    <string name="snooze_cancelled">Snooze cancelled</string>
+    <string name="snooze_not_active">No active snooze</string>
+    <string name="snooze_buttons_title">Snooze buttons</string>
+    <string name="snooze_buttons_summary">Choose up to 3 snooze durations to show on the alarm screen</string>
+    <!-- Notification sub-text label shown above the snooze minute buttons -->
+    <string name="notif_snooze_label">Snooze</string>
+    <!-- Notification action buttons: just the minute value, e.g. "30 min" -->
+    <string name="notif_snooze_min">%1$d min</string>
+    <!-- Notification action button: stop the alarm immediately (single tap) -->
+    <string name="notif_stop_alarm">Stop alarm</string>
+    <!-- Settings button: open system page to grant USE_FULL_SCREEN_INTENT (Android 14+) -->
+    <string name="alarm_fullscreen_grant">Grant full-screen alarm permission</string>
+
+    <!-- Persistent lock-screen glucose notification -->
+    <string name="permanent_glucose_notif">Glucose on lock screen</string>
+    <string name="permanent_notif_channel_name">Glucose status</string>
+    <string name="permanent_notif_channel_desc">Always-visible glucose value, trend and time on the lock screen</string>
+    <string name="trend_arrow_desc">Trend arrow</string>
+    <string name="glucose_graph_desc">Glucose history graph</string>
     <string name="usedweight">WARNING: weight (%.1f) not 0</string>
 
  <string name="verylowglucose">" Very LOW glucose!"</string>

--- a/Common/src/mobile/AndroidManifest.xml
+++ b/Common/src/mobile/AndroidManifest.xml
@@ -46,10 +46,12 @@
     <application
         android:name=".Applic"
         android:icon="@mipmap/ic_launcher"
-        android:label="@string/app_name"
-        android:theme="@style/AppTheme.Base">
+        android:label="${appLabel}"
+        android:theme="@style/AppTheme.Base"
+        tools:replace="android:label">
         <receiver
             android:name=".GlucoseWidget"
+            android:label="@string/widget_glucose"
             android:exported="false">
             <intent-filter>
                 <action android:name="android.appwidget.action.APPWIDGET_UPDATE" />
@@ -59,6 +61,82 @@
                 android:name="android.appwidget.provider"
                 android:resource="@xml/glucose_widget_info" />
         </receiver>
+
+        <!-- Widget: glucose value + trend arrow -->
+        <receiver
+            android:name=".GlucoseTrendWidget"
+            android:label="@string/widget_glucose_trend"
+            android:exported="false">
+            <intent-filter>
+                <action android:name="android.appwidget.action.APPWIDGET_UPDATE" />
+            </intent-filter>
+
+            <meta-data
+                android:name="android.appwidget.provider"
+                android:resource="@xml/glucose_trend_widget_info" />
+        </receiver>
+
+        <!-- Widget: glucose value + trend arrow + Δ delta -->
+        <receiver
+            android:name=".GlucoseTrendDeltaWidget"
+            android:label="@string/widget_glucose_trend_delta"
+            android:exported="false">
+            <intent-filter>
+                <action android:name="android.appwidget.action.APPWIDGET_UPDATE" />
+            </intent-filter>
+
+            <meta-data
+                android:name="android.appwidget.provider"
+                android:resource="@xml/glucose_trend_delta_widget_info" />
+        </receiver>
+
+        <!-- Widget: glucose value + trend arrow + Δ delta + elapsed time -->
+        <receiver
+            android:name=".GlucoseDeltaTimeWidget"
+            android:label="@string/widget_glucose_trend_delta_time"
+            android:exported="false">
+            <intent-filter>
+                <action android:name="android.appwidget.action.APPWIDGET_UPDATE" />
+            </intent-filter>
+
+            <meta-data
+                android:name="android.appwidget.provider"
+                android:resource="@xml/glucose_delta_time_widget_info" />
+        </receiver>
+
+        <!-- Widget: glucose value + trend arrow + Δ delta + elapsed time + 3h graph -->
+        <receiver
+            android:name=".ChartGlucoseWidget"
+            android:label="@string/widget_glucose_chart"
+            android:exported="false">
+            <intent-filter>
+                <action android:name="android.appwidget.action.APPWIDGET_UPDATE" />
+            </intent-filter>
+
+            <meta-data
+                android:name="android.appwidget.provider"
+                android:resource="@xml/chart_glucose_widget_info" />
+        </receiver>
+
+        <!-- BroadcastReceiver for snooze notification actions -->
+        <receiver
+            android:name=".SnoozeReceiver"
+            android:exported="false">
+            <intent-filter>
+                <action android:name="tk.glucodata.SNOOZE_ALARM" />
+            </intent-filter>
+        </receiver>
+
+        <!-- Full-screen lock-screen activity shown when a glucose alarm fires -->
+        <activity
+            android:name=".AlarmLockScreenActivity"
+            android:exported="false"
+            android:launchMode="singleInstance"
+            android:screenOrientation="portrait"
+            android:showWhenLocked="true"
+            android:turnScreenOn="true"
+            android:theme="@android:style/Theme.NoTitleBar.Fullscreen"
+            android:excludeFromRecents="true" />
 
         <activity
             android:name=".MainActivity"

--- a/Common/src/mobile/java/tk/glucodata/AlarmLockScreenActivity.java
+++ b/Common/src/mobile/java/tk/glucodata/AlarmLockScreenActivity.java
@@ -1,0 +1,481 @@
+/*      This file is part of Juggluco, an Android app to receive and display         */
+/*      glucose values from Freestyle Libre 2 and 3 sensors.                         */
+/*                                                                                   */
+/*      Copyright (C) 2021 Jaap Korthals Altes <jaapkorthalsaltes@gmail.com>         */
+/*                                                                                   */
+/*      Juggluco is free software: you can redistribute it and/or modify             */
+/*      it under the terms of the GNU General Public License as published            */
+/*      by the Free Software Foundation, either version 3 of the License, or         */
+/*      (at your option) any later version.                                          */
+/*                                                                                   */
+/*      Juggluco is distributed in the hope that it will be useful, but              */
+/*      WITHOUT ANY WARRANTY; without even the implied warranty of                   */
+/*      MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.                         */
+/*      See the GNU General Public License for more details.                         */
+/*                                                                                   */
+/*      You should have received a copy of the GNU General Public License            */
+/*      along with Juggluco. If not, see <https://www.gnu.org/licenses/>.            */
+
+package tk.glucodata;
+
+import static tk.glucodata.Log.doLog;
+
+import android.app.Activity;
+import android.app.NotificationManager;
+import android.content.Context;
+import android.content.Intent;
+import android.content.SharedPreferences;
+import android.graphics.Bitmap;
+import android.graphics.Paint;
+import android.net.Uri;
+import android.os.Build;
+import android.os.Bundle;
+import android.os.Handler;
+import android.os.Looper;
+import android.provider.Settings;
+import android.util.DisplayMetrics;
+import android.view.MotionEvent;
+import android.view.View;
+import android.view.WindowInsets;
+import android.view.WindowInsetsController;
+import android.view.WindowManager;
+import android.widget.Button;
+import android.widget.ImageView;
+import android.widget.LinearLayout;
+import android.widget.ProgressBar;
+import android.widget.TextView;
+
+/**
+ * Full-screen activity that appears on the lock screen when a glucose alarm
+ * fires.  Can be enabled/disabled from the Settings screen via
+ * {@link #setEnabled(boolean)}.  State is persisted in SharedPreferences.
+ *
+ * Inspired by GlucoDataHandler's {@code LockscreenActivity.kt}.
+ *
+ * Features:
+ *  - Dark charcoal background (#CC121212) matching Material dark surface
+ *  - Large glucose value (range-coloured) + Unicode trend arrow beside it
+ *  - Δ delta, 🕒 elapsed time, active-snooze status
+ *  - Hold-to-dismiss button (press and hold 1.5 s) — prevents accidental dismissal
+ *  - Snooze section — reveals snooze-duration buttons after tapping "Snooze"
+ *    (configurable in Settings, default 60/90/120 min)
+ *  - Auto-finishes after {@link #MAX_LIFETIME_MS} or when the alarm stops
+ */
+public class AlarmLockScreenActivity extends Activity {
+
+    private static final String LOG_ID  = "AlarmLockScreenActivity";
+    private static final String PREFS   = "juggluco_dev";
+    private static final String KEY_ALS = "alarm_lockscreen_enabled";
+
+    // ── enabled state (persisted) ─────────────────────────────────────────────
+
+    private static SharedPreferences prefs() {
+        return Applic.app.getSharedPreferences(PREFS, Context.MODE_PRIVATE);
+    }
+
+    /** Returns true when the alarm lock-screen activity is enabled (default: on). */
+    public static boolean isEnabled() {
+        return prefs().getBoolean(KEY_ALS, true);
+    }
+
+    /** Toggle from the Settings screen; persists immediately. */
+    public static void setEnabled(boolean on) {
+        prefs().edit().putBoolean(KEY_ALS, on).apply();
+    }
+
+    /**
+     * Returns true when the app has permission to fire full-screen intents.
+     * On Android 14+ (API 34) this requires explicit user approval.
+     * On older versions it is always granted.
+     */
+    public static boolean hasFullScreenIntentPermission() {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
+            final NotificationManager nm = (NotificationManager)
+                    Applic.app.getSystemService(Context.NOTIFICATION_SERVICE);
+            return nm != null && nm.canUseFullScreenIntent();
+        }
+        return true;
+    }
+
+    /**
+     * Opens the system Settings page where the user can grant the
+     * USE_FULL_SCREEN_INTENT permission (Android 14+ only).
+     * Safe to call on older versions — it is a no-op there.
+     */
+    public static void requestFullScreenIntentPermission(Context context) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
+            try {
+                final Intent intent = new Intent(
+                        Settings.ACTION_MANAGE_APP_USE_FULL_SCREEN_INTENT,
+                        Uri.parse("package:" + context.getPackageName()));
+                intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+                context.startActivity(intent);
+            } catch (Throwable t) {
+                Log.stack("AlarmLockScreenActivity", "requestFullScreenIntentPermission", t);
+            }
+        }
+    }
+
+    /** Intent extra: alarm kind integer (maps to {@link Notify#alarmtext(int)}). */
+    public static final String EXTRA_ALARM_KIND = "alarm_kind";
+
+    /** How long (ms) the activity stays open before auto-finishing. */
+    private static final long MAX_LIFETIME_MS = 5 * 60 * 1000L;   // 5 minutes
+
+    /**
+     * How long (ms) the user must hold the dismiss button before the alarm stops.
+     * Matching GDH's slide-to-act feel: long enough to be intentional.
+     */
+    private static final long HOLD_TO_DISMISS_MS = 1500L;
+
+    /** Tick interval for the hold-to-dismiss progress animation (ms). */
+    private static final long HOLD_TICK_MS = 30L;
+
+    private long createTime;
+    private int  alarmKind = -1;
+
+    // ── hold-to-dismiss state ─────────────────────────────────────────────────
+    private long     holdStartMs   = 0L;
+    private boolean  holdActive    = false;
+    private ProgressBar dismissProgress;
+    private final Handler holdHandler = new Handler(Looper.getMainLooper());
+    private final Runnable holdTicker = new Runnable() {
+        @Override public void run() {
+            if (!holdActive) return;
+            final long elapsed = System.currentTimeMillis() - holdStartMs;
+            final int pct = (int) Math.min(100, elapsed * 100 / HOLD_TO_DISMISS_MS);
+            dismissProgress.setProgress(pct);
+            if (elapsed >= HOLD_TO_DISMISS_MS) {
+                holdActive = false;
+                {if(doLog) {Log.i(LOG_ID, "hold-to-dismiss completed");}}
+                Notify.stopalarm();
+                finish();
+            } else {
+                holdHandler.postDelayed(this, HOLD_TICK_MS);
+            }
+        }
+    };
+
+    /** Handler used for the 1-minute live-refresh loop. */
+    private final Handler refreshHandler = new Handler(Looper.getMainLooper());
+    private final Runnable refreshRunnable = new Runnable() {
+        @Override public void run() {
+            if (currentInstance != AlarmLockScreenActivity.this) return;
+            updateDisplay();
+            if (!Natives.getisalarm()) {
+                {if(doLog) {Log.i(LOG_ID, "refreshRunnable: alarm stopped, finishing");}}
+                finish();
+                return;
+            }
+            refreshHandler.postDelayed(this, 60_000L);
+        }
+    };
+
+    /** Allows {@link Notify#stopalarm()} to close this activity remotely. */
+    private static AlarmLockScreenActivity currentInstance = null;
+
+    /** Close from outside (e.g. when alarm stop is triggered via notification). */
+    public static void close() {
+        final var act = currentInstance;
+        if (act != null) {
+            act.runOnUiThread(() -> {
+                try { act.finish(); } catch (Throwable ignored) {}
+            });
+        }
+    }
+
+    public static boolean isActive() {
+        return currentInstance != null;
+    }
+
+    // ── lifecycle ─────────────────────────────────────────────────────────────
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        try {
+            {if(doLog) {Log.i(LOG_ID, "onCreate");}}
+            currentInstance = this;
+            showWhenLockedAndTurnScreenOn();
+            super.onCreate(savedInstanceState);
+            setContentView(R.layout.activity_alarm_lockscreen);
+            hideSystemUI();
+
+            createTime = System.currentTimeMillis();
+
+            if (getIntent() != null && getIntent().hasExtra(EXTRA_ALARM_KIND)) {
+                alarmKind = getIntent().getIntExtra(EXTRA_ALARM_KIND, -1);
+            }
+
+            dismissProgress = findViewById(R.id.lockscreen_dismiss_progress);
+            updateDisplay();
+            wireButtons();
+            // Start 1-minute live-refresh loop so glucose value and elapsed time stay current
+            refreshHandler.postDelayed(refreshRunnable, 60_000L);
+
+        } catch (Throwable t) {
+            Log.stack(LOG_ID, "onCreate", t);
+        }
+    }
+
+    @Override
+    protected void onResume() {
+        super.onResume();
+        updateDisplay();
+        // Auto-finish if the alarm was already stopped while we were paused
+        if (!Natives.getisalarm()) {
+            {if(doLog) {Log.i(LOG_ID, "onResume: alarm no longer active, finishing");}}
+            finish();
+        }
+    }
+
+    @Override
+    protected void onDestroy() {
+        holdHandler.removeCallbacks(holdTicker);
+        refreshHandler.removeCallbacks(refreshRunnable);
+        if (currentInstance == this) {
+            currentInstance = null;
+        }
+        super.onDestroy();
+    }
+
+    // ── UI helpers ────────────────────────────────────────────────────────────
+
+    private void updateDisplay() {
+        try {
+            final var ng = SuperGattCallback.previousglucose;
+
+            // Alarm label
+            final TextView lblAlarm = findViewById(R.id.lockscreen_alarm_label);
+            if (alarmKind >= 0) {
+                lblAlarm.setText("\u26A0 " + Notify.alarmtext(alarmKind));
+            }
+
+            if (ng == null) return;
+
+            // Glucose value — range-coloured or gray when stale
+            final boolean stale =
+                (System.currentTimeMillis() - ng.time) > Notify.glucosetimeout;
+            final int valueColor = stale ? android.graphics.Color.LTGRAY
+                : RemoteGlucose.glucoseRangeColor(SuperGattCallback.previousglucosevalue);
+
+            final TextView tvValue = findViewById(R.id.lockscreen_glucose_value);
+            tvValue.setText(ng.value);
+            tvValue.setTextColor(valueColor);
+            if (stale) {
+                tvValue.setPaintFlags(tvValue.getPaintFlags() | Paint.STRIKE_THRU_TEXT_FLAG);
+            } else {
+                tvValue.setPaintFlags(tvValue.getPaintFlags() & ~Paint.STRIKE_THRU_TEXT_FLAG);
+            }
+
+            // Trend arrow — Unicode character matching Juggluco's rate thresholds
+            final TextView tvArrow = findViewById(R.id.lockscreen_trend_arrow);
+            tvArrow.setText(rateToArrow(ng.rate));
+            tvArrow.setTextColor(valueColor);
+
+            // Δ delta
+            final float delta5 = ng.rate * 5f;
+            final String deltaStr;
+            if (Float.isNaN(delta5)) {
+                deltaStr = "\u0394 --";
+            } else {
+                final String fmt = Applic.unit == 1 ? "%+.1f" : "%+.0f";
+                deltaStr = "\u0394 " + String.format(Applic.usedlocale, fmt, delta5);
+            }
+            final TextView tvDelta = findViewById(R.id.lockscreen_delta);
+            tvDelta.setText(deltaStr);
+            tvDelta.setTextColor(valueColor);
+
+            // Elapsed time with clock emoji (matches GDH)
+            final long elapsedMin = (System.currentTimeMillis() - ng.time) / 60_000L;
+            final TextView tvTime = findViewById(R.id.lockscreen_time);
+            tvTime.setText("\uD83D\uDD52 " + elapsedMin + " min");
+
+            // Active snooze label
+            final TextView tvSnoozeStatus = findViewById(R.id.lockscreen_snooze_status);
+            if (AlarmSnooze.isActive()) {
+                tvSnoozeStatus.setVisibility(View.VISIBLE);
+                tvSnoozeStatus.setText(
+                    getString(R.string.lockscreen_snoozed_until) + " " + AlarmSnooze.snoozeUntilText());
+            } else {
+                tvSnoozeStatus.setVisibility(View.GONE);
+            }
+
+            // 3-hour glucose history graph
+            final ImageView ivGraph = findViewById(R.id.lockscreen_graph);
+            if (ivGraph != null) {
+                if (Applic.Nativesloaded) {
+                    final Bitmap graphBmp = buildGraphBitmap();
+                    if (graphBmp != null) {
+                        ivGraph.setImageBitmap(graphBmp);
+                        ivGraph.setVisibility(View.VISIBLE);
+                    } else {
+                        ivGraph.setVisibility(View.GONE);
+                    }
+                } else {
+                    ivGraph.setVisibility(View.GONE);
+                }
+            }
+
+            // Auto-finish after MAX_LIFETIME_MS
+            if ((System.currentTimeMillis() - createTime) >= MAX_LIFETIME_MS) {
+                finish();
+            }
+        } catch (Throwable t) {
+            Log.stack(LOG_ID, "updateDisplay", t);
+        }
+    }
+
+    /**
+     * Convert glucose rate (mmol/L per min or mg/dL per min) to a Unicode direction arrow.
+     * Thresholds mirror Juggluco's own {@code RemoteGlucose.arrowremote()} logic:
+     *  rate > 1.6  → steep up    (↑↑)
+     *  rate > 0.6  → up          (↑)
+     *  rate > 0.2  → slight up   (↗)
+     *  rate > -0.2 → flat        (→)
+     *  rate > -0.6 → slight down (↘)
+     *  rate > -1.6 → down        (↓)
+     *  rate ≤ -1.6 → steep down  (↓↓)
+     *  NaN         → ?
+     */
+    private static String rateToArrow(float rate) {
+        if (Float.isNaN(rate)) return "?";
+        if (rate >  1.6f) return "\u21C8"; // ⇈
+        if (rate >  0.6f) return "\u2191"; // ↑
+        if (rate >  0.2f) return "\u2197"; // ↗
+        if (rate > -0.2f) return "\u2192"; // →
+        if (rate > -0.6f) return "\u2198"; // ↘
+        if (rate > -1.6f) return "\u2193"; // ↓
+        return "\u21CA";                    // ⇊
+    }
+
+    /**
+     * Renders a 3-hour glucose history graph using the NanoVG-RT JNI backend.
+     * Width is the full display width; height is 180 dp.
+     * Returns null if the native library is not loaded or the JNI call fails.
+     */
+    private Bitmap buildGraphBitmap() {
+        try {
+            final DisplayMetrics dm = getResources().getDisplayMetrics();
+            final int wPx = dm.widthPixels;
+            final int hPx = Math.round(180 * dm.density);
+            if (wPx < 60 || hPx < 40) return null;
+            final int[] pixels = Natives.getWidgetGraphBitmap(wPx, hPx, 3 * 3600);
+            if (pixels == null) return null;
+            return Bitmap.createBitmap(pixels, wPx, hPx, Bitmap.Config.ARGB_8888);
+        } catch (Throwable t) {
+            Log.stack(LOG_ID, "buildGraphBitmap", t);
+            return null;
+        }
+    }
+
+    @SuppressWarnings("ClickableViewAccessibility")
+    private void wireButtons() {
+        final Button btnDismiss = findViewById(R.id.lockscreen_dismiss_btn);
+        final Button btnSnoozeReveal = findViewById(R.id.lockscreen_snooze_reveal_btn);
+        final LinearLayout snoozeLayout = findViewById(R.id.lockscreen_snooze_layout);
+
+        // Label the Dismiss button with the re-fire interval and the hold instruction
+        final String dismissLabel;
+        if (alarmKind >= 0) {
+            final int reFireMin = Natives.readalarmsuspension(alarmKind);
+            dismissLabel = getString(R.string.lockscreen_dismiss_hold)
+                    + (reFireMin > 0 ? " (+" + reFireMin + " min)" : "");
+        } else {
+            dismissLabel = getString(R.string.lockscreen_dismiss_hold);
+        }
+        btnDismiss.setText(dismissLabel);
+
+        // Hold-to-dismiss: start countdown on ACTION_DOWN, cancel on ACTION_UP/CANCEL
+        btnDismiss.setOnTouchListener((v, event) -> {
+            switch (event.getAction()) {
+                case MotionEvent.ACTION_DOWN:
+                    {if(doLog) {Log.i(LOG_ID, "dismiss hold started");}}
+                    holdStartMs = System.currentTimeMillis();
+                    holdActive  = true;
+                    dismissProgress.setProgress(0);
+                    holdHandler.post(holdTicker);
+                    return true;
+                case MotionEvent.ACTION_UP:
+                case MotionEvent.ACTION_CANCEL:
+                    if (holdActive) {
+                        {if(doLog) {Log.i(LOG_ID, "dismiss hold cancelled");}}
+                        holdActive = false;
+                        holdHandler.removeCallbacks(holdTicker);
+                        dismissProgress.setProgress(0);
+                    }
+                    return true;
+            }
+            return false;
+        });
+
+        // Snooze — reveal the duration buttons
+        btnSnoozeReveal.setOnClickListener(v -> {
+            {if(doLog) {Log.i(LOG_ID, "snooze reveal tapped");}}
+            snoozeLayout.setVisibility(View.VISIBLE);
+            btnSnoozeReveal.setVisibility(View.GONE);
+        });
+
+        // Snooze duration buttons — populated dynamically from user's selection
+        final int[] btnIds = {
+            R.id.lockscreen_snooze_btn1,
+            R.id.lockscreen_snooze_btn2,
+            R.id.lockscreen_snooze_btn3
+        };
+        final java.util.List<Long> snoozeValues = AlarmSnooze.getSnoozeButtons();
+        for (int i = 0; i < btnIds.length; i++) {
+            final Button btn = findViewById(btnIds[i]);
+            if (btn == null) continue;
+            if (i < snoozeValues.size()) {
+                final long minutes = snoozeValues.get(i);
+                btn.setText(String.valueOf(minutes));
+                btn.setVisibility(View.VISIBLE);
+                btn.setOnClickListener(v -> {
+                    {if(doLog) {Log.i(LOG_ID, "snooze " + minutes + " min tapped");}}
+                    AlarmSnooze.set(minutes);
+                    Notify.stopalarm();
+                    finish();
+                });
+            } else {
+                btn.setVisibility(View.GONE);
+            }
+        }
+    }
+
+    // ── window flags ──────────────────────────────────────────────────────────
+
+    @SuppressWarnings("deprecation")
+    private void showWhenLockedAndTurnScreenOn() {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O_MR1) {
+            setShowWhenLocked(true);
+            setTurnScreenOn(true);
+        }
+        getWindow().addFlags(
+            WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON
+            | WindowManager.LayoutParams.FLAG_ALLOW_LOCK_WHILE_SCREEN_ON
+            | WindowManager.LayoutParams.FLAG_SHOW_WHEN_LOCKED
+            | WindowManager.LayoutParams.FLAG_TURN_SCREEN_ON
+            | WindowManager.LayoutParams.FLAG_DISMISS_KEYGUARD
+        );
+    }
+
+    @SuppressWarnings("deprecation")
+    private void hideSystemUI() {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+            final var wic = getWindow().getInsetsController();
+            if (wic != null) {
+                wic.hide(WindowInsets.Type.statusBars() | WindowInsets.Type.navigationBars());
+                wic.setSystemBarsBehavior(
+                    WindowInsetsController.BEHAVIOR_SHOW_TRANSIENT_BARS_BY_SWIPE);
+            }
+        } else {
+            getWindow().getDecorView().setSystemUiVisibility(
+                View.SYSTEM_UI_FLAG_FULLSCREEN
+                | View.SYSTEM_UI_FLAG_HIDE_NAVIGATION
+                | View.SYSTEM_UI_FLAG_IMMERSIVE_STICKY
+                | View.SYSTEM_UI_FLAG_LAYOUT_STABLE
+                | View.SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN
+                | View.SYSTEM_UI_FLAG_LAYOUT_HIDE_NAVIGATION
+            );
+        }
+    }
+}

--- a/Common/src/mobile/java/tk/glucodata/AlarmSnooze.java
+++ b/Common/src/mobile/java/tk/glucodata/AlarmSnooze.java
@@ -1,0 +1,138 @@
+/*      This file is part of Juggluco, an Android app to receive and display         */
+/*      glucose values from Freestyle Libre 2 and 3 sensors.                         */
+/*                                                                                   */
+/*      Copyright (C) 2021 Jaap Korthals Altes <jaapkorthalsaltes@gmail.com>         */
+/*                                                                                   */
+/*      Juggluco is free software: you can redistribute it and/or modify             */
+/*      it under the terms of the GNU General Public License as published            */
+/*      by the Free Software Foundation, either version 3 of the License, or         */
+/*      (at your option) any later version.                                          */
+/*                                                                                   */
+/*      Juggluco is distributed in the hope that it will be useful, but              */
+/*      WITHOUT ANY WARRANTY; without even the implied warranty of                   */
+/*      MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.                         */
+/*      See the GNU General Public License for more details.                         */
+/*                                                                                   */
+/*      You should have received a copy of the GNU General Public License            */
+/*      along with Juggluco. If not, see <https://www.gnu.org/licenses/>.            */
+
+package tk.glucodata;
+
+import android.content.Context;
+import android.content.SharedPreferences;
+
+import java.text.DateFormat;
+import java.util.Arrays;
+import java.util.Date;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.TreeSet;
+
+/**
+ * Manages alarm snooze state.  When the user presses a snooze button on the
+ * {@link AlarmLockScreenActivity}, alarms are suppressed until
+ * {@link #snoozeUntilMs()} has passed.
+ *
+ * Also persists which snooze-duration buttons are shown on the alarm UI
+ * (up to 3, chosen from 30/60/90/120 min — default 60/90/120, matching GDH).
+ *
+ * State is persisted so it survives a process restart.
+ */
+public class AlarmSnooze {
+
+    private static final String PREFS          = "juggluco_dev";
+    private static final String KEY_SNOOZE_END = "alarm_snooze_end_ms";
+    /** Comma-separated list of selected snooze durations, e.g. "60,90,120". */
+    private static final String KEY_SNOOZE_BTNS = "alarm_snooze_buttons";
+
+    /** All available snooze durations (minutes). */
+    public static final long[] ALL_DURATIONS = {30L, 60L, 90L, 120L};
+
+    /** Default selection when no preference has been saved yet. */
+    private static final Set<String> DEFAULT_BTNS =
+            new HashSet<>(Arrays.asList("60", "90", "120"));
+
+    /** In-memory cache; initialised from prefs on first access via {@link #init()}. */
+    private static volatile long snoozeEndMs = 0L;
+    private static boolean       initialised = false;
+
+    // ── init ─────────────────────────────────────────────────────────────────
+
+    /** Call once at startup (e.g. from keeprunning) to restore persisted state. */
+    public static void init() {
+        snoozeEndMs = prefs().getLong(KEY_SNOOZE_END, 0L);
+        initialised = true;
+    }
+
+    // ── snooze active state ───────────────────────────────────────────────────
+
+    /** Returns true when a snooze is currently active (not yet expired). */
+    public static boolean isActive() {
+        if (!initialised) init();
+        return snoozeEndMs > System.currentTimeMillis();
+    }
+
+    /**
+     * Start a snooze for the given number of minutes.
+     * Pass 0 to cancel an active snooze immediately.
+     */
+    public static void set(long minutes) {
+        if (!initialised) init();
+        snoozeEndMs = minutes > 0
+                ? System.currentTimeMillis() + minutes * 60_000L
+                : 0L;
+        prefs().edit().putLong(KEY_SNOOZE_END, snoozeEndMs).apply();
+    }
+
+    /** The absolute end time of the current snooze (0 if not active). */
+    public static long snoozeUntilMs() {
+        if (!initialised) init();
+        return snoozeEndMs;
+    }
+
+    /**
+     * Human-readable "until HH:mm" string for status display.
+     * Returns an empty string if no snooze is active.
+     */
+    public static String snoozeUntilText() {
+        if (!isActive()) return "";
+        return DateFormat.getTimeInstance(DateFormat.SHORT).format(new Date(snoozeEndMs));
+    }
+
+    // ── snooze button configuration ───────────────────────────────────────────
+
+    /**
+     * Returns the currently configured snooze durations (minutes), sorted
+     * ascending, capped at 3 entries — matching GDH behaviour.
+     * Default is {60, 90, 120}.
+     */
+    public static List<Long> getSnoozeButtons() {
+        final Set<String> raw = prefs().getStringSet(KEY_SNOOZE_BTNS, DEFAULT_BTNS);
+        // TreeSet sorts them; map to Long; take at most 3
+        final TreeSet<Long> sorted = new TreeSet<>();
+        for (String s : raw) {
+            try { sorted.add(Long.parseLong(s)); } catch (NumberFormatException ignored) {}
+        }
+        return sorted.stream().limit(3).collect(java.util.stream.Collectors.toList());
+    }
+
+    /**
+     * Persist a new set of selected snooze durations.
+     * @param selected set of minute-values as strings, e.g. {"60","90","120"}
+     */
+    public static void setSnoozeButtons(Set<String> selected) {
+        prefs().edit().putStringSet(KEY_SNOOZE_BTNS, selected).apply();
+    }
+
+    /** Returns the raw persisted set of button values (strings) for UI display. */
+    public static Set<String> getSnoozeButtonsRaw() {
+        return prefs().getStringSet(KEY_SNOOZE_BTNS, DEFAULT_BTNS);
+    }
+
+    // ── helpers ───────────────────────────────────────────────────────────────
+
+    private static SharedPreferences prefs() {
+        return Applic.app.getSharedPreferences(PREFS, Context.MODE_PRIVATE);
+    }
+}

--- a/Common/src/mobile/java/tk/glucodata/ChartGlucoseWidget.java
+++ b/Common/src/mobile/java/tk/glucodata/ChartGlucoseWidget.java
@@ -1,0 +1,328 @@
+/*      This file is part of Juggluco, an Android app to receive and display         */
+/*      glucose values from Freestyle Libre 2 and 3 sensors.                         */
+/*                                                                                   */
+/*      Copyright (C) 2021 Jaap Korthals Altes <jaapkorthalsaltes@gmail.com>         */
+/*                                                                                   */
+/*      Juggluco is free software: you can redistribute it and/or modify             */
+/*      it under the terms of the GNU General Public License as published            */
+/*      by the Free Software Foundation, either version 3 of the License, or         */
+/*      (at your option) any later version.                                          */
+/*                                                                                   */
+/*      Juggluco is distributed in the hope that it will be useful, but              */
+/*      WITHOUT ANY WARRANTY; without even the implied warranty of                   */
+/*      MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.                         */
+/*      See the GNU General Public License for more details.                         */
+/*                                                                                   */
+/*      You should have received a copy of the GNU General Public License            */
+/*      along with Juggluco. If not, see <https://www.gnu.org/licenses/>.            */
+
+package tk.glucodata;
+
+import static tk.glucodata.Log.doLog;
+import static tk.glucodata.Notify.glucosetimeout;
+import static tk.glucodata.Notify.penmutable;
+
+import android.app.PendingIntent;
+import android.appwidget.AppWidgetManager;
+import android.appwidget.AppWidgetProvider;
+import android.content.BroadcastReceiver;
+import android.content.ComponentName;
+import android.content.Context;
+import android.content.Intent;
+import android.content.IntentFilter;
+import android.graphics.Bitmap;
+import android.graphics.Canvas;
+import android.graphics.Color;
+import android.graphics.Paint;
+import android.graphics.PorterDuff;
+import android.os.Build;
+import android.os.Bundle;
+import android.util.DisplayMetrics;
+import android.view.View;
+import android.widget.RemoteViews;
+
+/**
+ * Home-screen widget showing:
+ *
+ *   ┌─────────────────────────────────────┐
+ *   │  202  →    │  🕒 3 min  │  Δ +5    │  ← normal/long cell
+ *   │─────────────────────────────────────│
+ *   │   [  glucose history graph (3 h)  ] │
+ *   └─────────────────────────────────────┘
+ *
+ * Layout variants selected by widget cell size:
+ *   • short  (w ≤ 110 dp): value + arrow only (no graph, no time/delta)
+ *   • normal (default)   : value | arrow | time | delta | graph
+ *   • long   (ratio > 2) : horizontal value+arrow on left, graph on right
+ *
+ * The graph is rendered off-screen using the NanoVG-RT software backend
+ * via {@link Natives#getWidgetGraphBitmap(int, int, int)}.
+ *
+ * Reuses the identical pattern (range colour, strikethrough, arrow bitmap,
+ * tick receiver) from GlucoseDeltaTimeWidget.
+ */
+public class ChartGlucoseWidget extends AppWidgetProvider {
+
+    private static final String LOG_ID = "ChartGlucoseWidget";
+
+    /** Graph history window — 3 hours, matching GDH's ChartWidget default. */
+    static final int GRAPH_DURATION_SECS = 3 * 3600;
+
+    /**
+     * Target graph height in dp inside the normal widget.
+     * The ImageView uses weight=3 in a vertical LinearLayout whose total height
+     * is ~250 dp on a 2-row cell; so ~150 dp is a good estimate.
+     */
+    private static final int GRAPH_HEIGHT_DP = 130;
+
+    static boolean used = true;
+
+    /** Receives ACTION_TIME_TICK to refresh the elapsed-time counter every minute. */
+    private static BroadcastReceiver tickReceiver = null;
+
+    // ── layout selection ──────────────────────────────────────────────────────
+
+    /** Short: narrow cell (≤ 110 dp wide) — glucose + arrow only, no graph */
+    static boolean isShort(int widthDp, int heightDp) {
+        return widthDp <= 110 || heightDp <= 70;
+    }
+
+    /** Long: wide cell (aspect ratio > 2.0) — horizontal split, graph on right */
+    static boolean isLong(int widthDp, int heightDp) {
+        return heightDp > 0 && ((float) widthDp / heightDp) > 2.0f;
+    }
+
+    // ── core update ───────────────────────────────────────────────────────────
+
+    private static void updateOne(AppWidgetManager mgr, int appWidgetId) {
+        try {
+            // ── gather glucose data ──────────────────────────────────────────
+            notGlucose ng = SuperGattCallback.previousglucose;
+            if (ng == null) {
+                strGlucose glu = Natives.lastglucose();
+                if (glu != null) {
+                    ng = new notGlucose(glu.time * 1000L, glu.value, glu.rate, glu.sensorgen2);
+                    SuperGattCallback.previousglucose = ng;
+                }
+            }
+
+            // ── read widget cell size ────────────────────────────────────────
+            final Bundle options = mgr.getAppWidgetOptions(appWidgetId);
+            final int wDp = options.getInt(AppWidgetManager.OPTION_APPWIDGET_MIN_WIDTH, 150);
+            final int hDp = options.getInt(AppWidgetManager.OPTION_APPWIDGET_MAX_HEIGHT, 200);
+            final boolean shortWidget = isShort(wDp, hDp);
+            final boolean longWidget  = !shortWidget && isLong(wDp, hDp);
+
+            // ── pick layout ──────────────────────────────────────────────────
+            final int layoutId;
+            if (shortWidget) layoutId = R.layout.chart_glucose_widget_short;
+            else if (longWidget) layoutId = R.layout.chart_glucose_widget_long;
+            else layoutId = R.layout.chart_glucose_widget;
+
+            final RemoteViews views = new RemoteViews(Applic.app.getPackageName(), layoutId);
+
+            // ── tap opens app ────────────────────────────────────────────────
+            final Intent tapIntent = new Intent(Applic.app, MainActivity.class);
+            final PendingIntent tapPi = PendingIntent.getActivity(
+                    Applic.app, 0, tapIntent, PendingIntent.FLAG_UPDATE_CURRENT | penmutable);
+            views.setOnClickPendingIntent(R.id.cgw_root, tapPi);
+
+            // ── background ───────────────────────────────────────────────────
+            final int bgAlpha = RemoteGlucose.getWidgetBgAlpha();
+            views.setInt(R.id.cgw_root, "setBackgroundColor",
+                    bgAlpha > 0 ? Color.argb(bgAlpha, 0, 0, 0) : Color.TRANSPARENT);
+
+            // ── no data ──────────────────────────────────────────────────────
+            if (ng == null) {
+                views.setTextViewText(R.id.cgw_glucose, "- -");
+                views.setTextColor(R.id.cgw_glucose, Color.RED);
+                views.setViewVisibility(R.id.cgw_arrow, View.GONE);
+                if (!shortWidget) {
+                    views.setTextViewText(R.id.cgw_time,  "");
+                    views.setTextViewText(R.id.cgw_delta, "");
+                    views.setViewVisibility(R.id.cgw_graph, View.GONE);
+                }
+                mgr.updateAppWidget(appWidgetId, views);
+                return;
+            }
+
+            // ── colours ──────────────────────────────────────────────────────
+            final boolean stale = (System.currentTimeMillis() - ng.time) > glucosetimeout;
+            final int valueColor = stale
+                    ? Color.GRAY
+                    : RemoteGlucose.glucoseRangeColor(SuperGattCallback.previousglucosevalue);
+            final int textColor = (Notify.foregroundcolor != Color.BLACK)
+                    ? Notify.foregroundcolor : Color.WHITE;
+
+            // ── glucose value ─────────────────────────────────────────────────
+            views.setTextViewText(R.id.cgw_glucose, ng.value);
+            views.setTextColor(R.id.cgw_glucose, valueColor);
+            views.setInt(R.id.cgw_glucose, "setPaintFlags",
+                    stale ? android.graphics.Paint.STRIKE_THRU_TEXT_FLAG : 0);
+
+            // ── trend arrow ───────────────────────────────────────────────────
+            final float rate = ng.rate;
+            if (!Float.isNaN(rate) && !stale) {
+                views.setImageViewBitmap(R.id.cgw_arrow, buildArrowBitmap(rate, valueColor));
+                views.setViewVisibility(R.id.cgw_arrow, View.VISIBLE);
+            } else {
+                views.setViewVisibility(R.id.cgw_arrow, View.GONE);
+            }
+
+            // ── time + delta (not shown in short layout) ──────────────────────
+            if (!shortWidget) {
+                final long elapsedMin = (System.currentTimeMillis() - ng.time) / 60_000L;
+                views.setTextViewText(R.id.cgw_time, "\uD83D\uDD52 " + elapsedMin + " min");
+                views.setTextColor(R.id.cgw_time, textColor);
+
+                final float delta5 = rate * 5f;
+                final String deltaStr = Float.isNaN(delta5) ? "\u0394 --"
+                        : "\u0394 " + String.format(Applic.usedlocale,
+                              Applic.unit == 1 ? "%+.1f" : "%+.0f", delta5);
+                views.setTextViewText(R.id.cgw_delta, deltaStr);
+                views.setTextColor(R.id.cgw_delta, valueColor);
+
+                // ── graph bitmap ──────────────────────────────────────────────
+                final Bitmap graphBmp = buildGraphBitmap(wDp, hDp, longWidget);
+                if (graphBmp != null) {
+                    views.setImageViewBitmap(R.id.cgw_graph, graphBmp);
+                    views.setViewVisibility(R.id.cgw_graph, View.VISIBLE);
+                } else {
+                    views.setViewVisibility(R.id.cgw_graph, View.GONE);
+                }
+            }
+
+            mgr.updateAppWidget(appWidgetId, views);
+        } catch (Throwable th) {
+            Log.stack(LOG_ID, "updateOne", th);
+        }
+    }
+
+    // ── graph rendering ───────────────────────────────────────────────────────
+
+    /**
+     * Render the glucose history graph off-screen using NanoVG-RT.
+     *
+     * <p>For the normal layout the graph takes roughly the bottom 55 % of the
+     * widget height.  For the long layout it takes the full height on the right
+     * half.  We use density-independent pixels from the AppWidgetManager options
+     * and convert to pixels with the display density.
+     *
+     * <p>Returns null when the native library is not loaded or has no data.
+     */
+    private static Bitmap buildGraphBitmap(int widgetWDp, int widgetHDp, boolean longLayout) {
+        if (!Applic.Nativesloaded) return null;
+        final DisplayMetrics dm = Applic.app.getResources().getDisplayMetrics();
+        final float density = dm.density;
+
+        final int graphWPx, graphHPx;
+        if (longLayout) {
+            // Right half of the cell
+            graphWPx = Math.round(widgetWDp * density * 0.55f);
+            graphHPx = Math.round(widgetHDp * density * 0.90f);
+        } else {
+            // Bottom 55 % of the cell
+            graphWPx = Math.round(widgetWDp  * density * 0.95f);
+            graphHPx = Math.round(GRAPH_HEIGHT_DP * density);
+        }
+
+        if (graphWPx < 60 || graphHPx < 40) return null;
+
+        try {
+            final int[] pixels = Natives.getWidgetGraphBitmap(
+                    graphWPx, graphHPx, GRAPH_DURATION_SECS);
+            if (pixels == null) return null;
+            return Bitmap.createBitmap(pixels, graphWPx, graphHPx, Bitmap.Config.ARGB_8888);
+        } catch (Throwable th) {
+            Log.stack(LOG_ID, "buildGraphBitmap", th);
+            return null;
+        }
+    }
+
+    // ── arrow bitmap (shared helper) ─────────────────────────────────────────
+
+    private static Bitmap buildArrowBitmap(float rate, int color) {
+        final int size = 128;
+        final Bitmap bmp = Bitmap.createBitmap(size, size, Bitmap.Config.ARGB_8888);
+        final Canvas cv = new Canvas(bmp);
+        cv.drawColor(Color.TRANSPARENT, PorterDuff.Mode.CLEAR);
+        final Paint p = new Paint();
+        p.setAntiAlias(true);
+        p.setColor(color);
+        p.setStrokeWidth(4f);
+        CommonCanvas.drawarrow(cv, p, size / 54f, rate, size * 0.65f, size * 0.50f);
+        return bmp;
+    }
+
+    // ── batch update ──────────────────────────────────────────────────────────
+
+    private static void updateAll(AppWidgetManager mgr, int[] ids) {
+        if (ids == null || ids.length == 0) return;
+        used = true;
+        for (int id : ids) updateOne(mgr, id);
+    }
+
+    /** Called from GlucoseWidget.update() when a new sensor reading arrives. */
+    public static void update() {
+        if (!used) return;
+        final AppWidgetManager mgr = AppWidgetManager.getInstance(Applic.app);
+        final int[] ids = mgr.getAppWidgetIds(
+                new ComponentName(Applic.app, ChartGlucoseWidget.class));
+        if (ids.length > 0) {
+            updateAll(mgr, ids);
+        } else {
+            used = false;
+        }
+    }
+
+    // ── AppWidgetProvider callbacks ───────────────────────────────────────────
+
+    @Override
+    public void onUpdate(Context ctx, AppWidgetManager mgr, int[] ids) {
+        {if(doLog) {Log.i(LOG_ID, "onUpdate ids=" + ids.length);};};
+        updateAll(mgr, ids);
+    }
+
+    @Override
+    public void onAppWidgetOptionsChanged(Context ctx, AppWidgetManager mgr,
+                                          int id, Bundle opts) {
+        {if(doLog) {Log.i(LOG_ID, "onAppWidgetOptionsChanged id=" + id);};};
+        used = true;
+        updateOne(mgr, id);
+    }
+
+    @Override
+    public void onEnabled(Context ctx) {
+        used = true;
+        registerTickReceiver(ctx);
+    }
+
+    @Override
+    public void onDisabled(Context ctx) {
+        used = false;
+        unregisterTickReceiver(ctx);
+    }
+
+    // ── tick receiver (refreshes elapsed time every minute) ───────────────────
+
+    private static void registerTickReceiver(Context ctx) {
+        if (tickReceiver != null) return;
+        tickReceiver = new BroadcastReceiver() {
+            @Override public void onReceive(Context c, Intent i) { update(); }
+        };
+        final IntentFilter filter = new IntentFilter(Intent.ACTION_TIME_TICK);
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            ctx.getApplicationContext().registerReceiver(
+                    tickReceiver, filter, Context.RECEIVER_NOT_EXPORTED);
+        } else {
+            ctx.getApplicationContext().registerReceiver(tickReceiver, filter);
+        }
+    }
+
+    private static void unregisterTickReceiver(Context ctx) {
+        if (tickReceiver == null) return;
+        try { ctx.getApplicationContext().unregisterReceiver(tickReceiver); }
+        catch (Throwable ignored) {}
+        tickReceiver = null;
+    }
+}

--- a/Common/src/mobile/java/tk/glucodata/GlucoseDeltaTimeWidget.java
+++ b/Common/src/mobile/java/tk/glucodata/GlucoseDeltaTimeWidget.java
@@ -1,0 +1,258 @@
+/*      This file is part of Juggluco, an Android app to receive and display         */
+/*      glucose values from Freestyle Libre 2 and 3 sensors.                         */
+/*                                                                                   */
+/*      Copyright (C) 2021 Jaap Korthals Altes <jaapkorthalsaltes@gmail.com>         */
+/*                                                                                   */
+/*      Juggluco is free software: you can redistribute it and/or modify             */
+/*      it under the terms of the GNU General Public License as published            */
+/*      by the Free Software Foundation, either version 3 of the License, or         */
+/*      (at your option) any later version.                                          */
+/*                                                                                   */
+/*      Juggluco is distributed in the hope that it will be useful, but              */
+/*      WITHOUT ANY WARRANTY; without even the implied warranty of                   */
+/*      MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.                         */
+/*      See the GNU General Public License for more details.                         */
+/*                                                                                   */
+/*      You should have received a copy of the GNU General Public License            */
+/*      along with Juggluco. If not, see <https://www.gnu.org/licenses/>.            */
+
+package tk.glucodata;
+
+import static tk.glucodata.Log.doLog;
+import static tk.glucodata.Notify.glucosetimeout;
+import static tk.glucodata.Notify.penmutable;
+
+import android.app.PendingIntent;
+import android.appwidget.AppWidgetManager;
+import android.appwidget.AppWidgetProvider;
+import android.content.BroadcastReceiver;
+import android.content.ComponentName;
+import android.content.Context;
+import android.content.Intent;
+import android.content.IntentFilter;
+import android.graphics.Bitmap;
+import android.graphics.Canvas;
+import android.graphics.Color;
+import android.graphics.Paint;
+import android.graphics.PorterDuff;
+import android.os.Build;
+import android.os.Bundle;
+import android.view.View;
+import android.widget.RemoteViews;
+
+/**
+ * Home-screen widget showing glucose value (auto-sized, range-coloured),
+ * a trend arrow, Δ delta, and elapsed time.
+ *
+ * Uses native RemoteViews TextViews with autoSizeTextType="uniform" so the
+ * glucose value always fills the available cell height — exactly like GDH's
+ * GlucoseTrendDeltaTimeWidget.  The trend arrow is rendered as a small bitmap
+ * via CommonCanvas.drawarrow() and set on an ImageView.
+ */
+public class GlucoseDeltaTimeWidget extends AppWidgetProvider {
+
+    private static final String LOG_ID = "GlucoseDeltaTimeWidget";
+    static boolean used = true;
+
+    /** Receives ACTION_TIME_TICK to refresh the widget display every minute. */
+    private static BroadcastReceiver tickReceiver = null;
+
+    private static int getLayout(AppWidgetManager mgr, int appWidgetId) {
+        final Bundle options = mgr.getAppWidgetOptions(appWidgetId);
+        final int minWidth = options.getInt(AppWidgetManager.OPTION_APPWIDGET_MIN_WIDTH);
+        final int maxHeight = options.getInt(AppWidgetManager.OPTION_APPWIDGET_MAX_HEIGHT);
+        final float ratio = maxHeight > 0 ? (minWidth / (float) maxHeight) : Float.MAX_VALUE;
+        if (minWidth <= 110 || ratio < 0.5f) {
+            return R.layout.glucose_delta_widget_short;
+        }
+        if (ratio > 2.8f) {
+            return R.layout.glucose_delta_widget_long;
+        }
+        return R.layout.glucose_delta_widget;
+    }
+
+    private static void updateOne(AppWidgetManager mgr, int appWidgetId) {
+        try {
+            strGlucose glu;
+            notGlucose ng = SuperGattCallback.previousglucose;
+            if (ng == null) {
+                glu = Natives.lastglucose();
+                if (glu != null) {
+                    ng = new notGlucose(glu.time * 1000L, glu.value, glu.rate, glu.sensorgen2);
+                    SuperGattCallback.previousglucose = ng;
+                }
+            }
+
+            final int layout = getLayout(mgr, appWidgetId);
+
+            if (ng == null) {
+                RemoteViews views = new RemoteViews(Applic.app.getPackageName(), layout);
+                views.setTextViewText(R.id.dtw_glucose, "- -");
+                views.setTextColor(R.id.dtw_glucose, Color.RED);
+                views.setTextViewText(R.id.dtw_delta, "");
+                views.setTextViewText(R.id.dtw_time, "");
+                Intent noDataIntent = new Intent(Applic.app, MainActivity.class);
+                PendingIntent noDataPi = PendingIntent.getActivity(
+                        Applic.app, 0, noDataIntent, PendingIntent.FLAG_UPDATE_CURRENT | penmutable);
+                views.setOnClickPendingIntent(R.id.glucose_delta_widget_root, noDataPi);
+                mgr.updateAppWidget(appWidgetId, views);
+                return;
+            }
+
+            final boolean stale = (System.currentTimeMillis() - ng.time) > glucosetimeout;
+            final int valueColor = stale
+                    ? Color.GRAY
+                    : RemoteGlucose.glucoseRangeColor(SuperGattCallback.previousglucosevalue);
+            // Time/delta use the system foreground color (white on dark, black on light)
+            // — same as GDH's transparent_widget_textcolor
+            final int textColor = Notify.foregroundcolor != Color.BLACK
+                    ? Notify.foregroundcolor : Color.WHITE;
+
+            RemoteViews views = new RemoteViews(Applic.app.getPackageName(), layout);
+
+            // Background tint (0 = transparent by default)
+            final int bgAlpha = RemoteGlucose.getWidgetBgAlpha();
+            if (bgAlpha > 0) {
+                views.setInt(R.id.glucose_delta_widget_root, "setBackgroundColor",
+                        Color.argb(bgAlpha, 0, 0, 0));
+            } else {
+                views.setInt(R.id.glucose_delta_widget_root, "setBackgroundColor",
+                        Color.TRANSPARENT);
+            }
+
+            // ── glucose value ──────────────────────────────────────────────
+            views.setTextViewText(R.id.dtw_glucose, ng.value);
+            views.setTextColor(R.id.dtw_glucose, valueColor);
+            if (stale) {
+                views.setInt(R.id.dtw_glucose, "setPaintFlags",
+                        android.graphics.Paint.STRIKE_THRU_TEXT_FLAG);
+            } else {
+                views.setInt(R.id.dtw_glucose, "setPaintFlags", 0);
+            }
+
+            // ── trend arrow bitmap ─────────────────────────────────────────
+            final float rate = ng.rate;
+            if (!Float.isNaN(rate)) {
+                final Bitmap arrowBmp = buildArrowBitmap(rate, valueColor);
+                views.setImageViewBitmap(R.id.dtw_arrow, arrowBmp);
+                views.setViewVisibility(R.id.dtw_arrow, View.VISIBLE);
+            } else {
+                views.setViewVisibility(R.id.dtw_arrow, View.GONE);
+            }
+
+            // ── elapsed time (🕒 prefix like GDH) ─────────────────────────
+            final long elapsedMin = (System.currentTimeMillis() - ng.time) / 60_000L;
+            views.setTextViewText(R.id.dtw_time, "\uD83D\uDD52 " + elapsedMin + " min");
+            views.setTextColor(R.id.dtw_time, textColor);
+
+            // ── delta ──────────────────────────────────────────────────────
+            final float delta5 = ng.rate * 5f;
+            final String deltaStr = Float.isNaN(delta5) ? "\u0394 --"
+                    : "\u0394 " + String.format(Applic.usedlocale,
+                          Applic.unit == 1 ? "%+.1f" : "%+.0f", delta5);
+            views.setTextViewText(R.id.dtw_delta, deltaStr);
+            views.setTextColor(R.id.dtw_delta, valueColor);
+
+            // ── tap opens app ──────────────────────────────────────────────
+            Intent intent = new Intent(Applic.app, MainActivity.class);
+            PendingIntent pi = PendingIntent.getActivity(
+                    Applic.app, 0, intent, PendingIntent.FLAG_UPDATE_CURRENT | penmutable);
+            views.setOnClickPendingIntent(R.id.glucose_delta_widget_root, pi);
+
+            mgr.updateAppWidget(appWidgetId, views);
+        } catch (Throwable th) {
+            Log.stack(LOG_ID, "updateOne", th);
+        }
+    }
+
+    /**
+     * Render the trend arrow into a square bitmap.
+     * Size is 128×128 px — RemoteViews ImageView will scale it with fitCenter.
+     */
+    private static Bitmap buildArrowBitmap(float rate, int color) {
+        final int size = 128;
+        final Bitmap bmp = Bitmap.createBitmap(size, size, Bitmap.Config.ARGB_8888);
+        final Canvas cv = new Canvas(bmp);
+        cv.drawColor(Color.TRANSPARENT, PorterDuff.Mode.CLEAR);
+        final Paint p = new Paint();
+        p.setAntiAlias(true);
+        p.setColor(color);
+        p.setStrokeWidth(4f);
+        // drawarrow density: arrow length ≈ 40% of size
+        final float density = size / 54f;
+        final float cx = size * 0.65f;
+        final float cy = size * 0.50f;
+        CommonCanvas.drawarrow(cv, p, density, rate, cx, cy);
+        return bmp;
+    }
+
+    private static void updateAll(AppWidgetManager mgr, int[] ids) {
+        if (ids == null || ids.length == 0) return;
+        used = true;
+        for (int id : ids) updateOne(mgr, id);
+    }
+
+    // ── AppWidgetProvider callbacks ───────────────────────────────────────────
+
+    @Override
+    public void onUpdate(Context ctx, AppWidgetManager mgr, int[] ids) {
+        {if(doLog) {Log.i(LOG_ID, "onUpdate");};};
+        updateAll(mgr, ids);
+    }
+
+    @Override
+    public void onAppWidgetOptionsChanged(Context ctx, AppWidgetManager mgr,
+                                          int id, Bundle opts) {
+        {if(doLog) {Log.i(LOG_ID, "onAppWidgetOptionsChanged");};};
+        used = true;
+        updateOne(mgr, id);
+    }
+
+    @Override
+    public void onEnabled(Context ctx) {
+        used = true;
+        registerTickReceiver(ctx);
+    }
+
+    @Override
+    public void onDisabled(Context ctx) {
+        used = false;
+        unregisterTickReceiver(ctx);
+    }
+
+    private static void registerTickReceiver(Context ctx) {
+        if (tickReceiver != null) return;
+        tickReceiver = new BroadcastReceiver() {
+            @Override public void onReceive(Context c, Intent i) { update(); }
+        };
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            ctx.getApplicationContext().registerReceiver(tickReceiver,
+                    new IntentFilter(Intent.ACTION_TIME_TICK),
+                    Context.RECEIVER_NOT_EXPORTED);
+        } else {
+            ctx.getApplicationContext().registerReceiver(tickReceiver,
+                    new IntentFilter(Intent.ACTION_TIME_TICK));
+        }
+    }
+
+    private static void unregisterTickReceiver(Context ctx) {
+        if (tickReceiver == null) return;
+        try { ctx.getApplicationContext().unregisterReceiver(tickReceiver); }
+        catch (Throwable ignored) {}
+        tickReceiver = null;
+    }
+
+    // ── Called from GlucoseWidget.update() when new data arrives ─────────────
+
+    public static void update() {
+        if (!used) return;
+        final var mgr = AppWidgetManager.getInstance(Applic.app);
+        final int[] ids = mgr.getAppWidgetIds(
+                new ComponentName(Applic.app, GlucoseDeltaTimeWidget.class));
+        if (ids.length > 0) {
+            updateAll(mgr, ids);
+        } else {
+            used = false;
+        }
+    }
+}

--- a/Common/src/mobile/java/tk/glucodata/GlucoseTrendDeltaWidget.java
+++ b/Common/src/mobile/java/tk/glucodata/GlucoseTrendDeltaWidget.java
@@ -1,0 +1,232 @@
+/*      This file is part of Juggluco, an Android app to receive and display         */
+/*      glucose values from Freestyle Libre 2 and 3 sensors.                         */
+/*                                                                                   */
+/*      Copyright (C) 2021 Jaap Korthals Altes <jaapkorthalsaltes@gmail.com>         */
+/*                                                                                   */
+/*      Juggluco is free software: you can redistribute it and/or modify             */
+/*      it under the terms of the GNU General Public License as published            */
+/*      by the Free Software Foundation, either version 3 of the License, or         */
+/*      (at your option) any later version.                                          */
+/*                                                                                   */
+/*      Juggluco is distributed in the hope that it will be useful, but              */
+/*      WITHOUT ANY WARRANTY; without even the implied warranty of                   */
+/*      MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.                         */
+/*      See the GNU General Public License for more details.                         */
+/*                                                                                   */
+/*      You should have received a copy of the GNU General Public License            */
+/*      along with Juggluco. If not, see <https://www.gnu.org/licenses/>.            */
+
+package tk.glucodata;
+
+import static tk.glucodata.Log.doLog;
+import static tk.glucodata.Notify.glucosetimeout;
+import static tk.glucodata.Notify.penmutable;
+
+import android.app.PendingIntent;
+import android.appwidget.AppWidgetManager;
+import android.appwidget.AppWidgetProvider;
+import android.content.BroadcastReceiver;
+import android.content.ComponentName;
+import android.content.Context;
+import android.content.Intent;
+import android.content.IntentFilter;
+import android.graphics.Bitmap;
+import android.graphics.Canvas;
+import android.graphics.Color;
+import android.graphics.Paint;
+import android.graphics.PorterDuff;
+import android.os.Build;
+import android.os.Bundle;
+import android.view.View;
+import android.widget.RemoteViews;
+
+/**
+ * Home-screen widget showing glucose value (auto-sized, range-coloured),
+ * a trend arrow, and Δ delta. No elapsed time row.
+ * Equivalent to GDH's GlucoseTrendDeltaWidget.
+ */
+public class GlucoseTrendDeltaWidget extends AppWidgetProvider {
+
+    private static final String LOG_ID = "GlucoseTrendDeltaWidget";
+    static boolean used = true;
+
+    /** Receives ACTION_TIME_TICK to refresh the widget display every minute. */
+    private static BroadcastReceiver tickReceiver = null;
+
+    private static int getLayout(AppWidgetManager mgr, int appWidgetId) {
+        final Bundle options = mgr.getAppWidgetOptions(appWidgetId);
+        final int minWidth = options.getInt(AppWidgetManager.OPTION_APPWIDGET_MIN_WIDTH);
+        final int maxHeight = options.getInt(AppWidgetManager.OPTION_APPWIDGET_MAX_HEIGHT);
+        final float ratio = maxHeight > 0 ? (minWidth / (float) maxHeight) : Float.MAX_VALUE;
+        if (minWidth <= 110 || ratio < 0.5f) {
+            return R.layout.glucose_trend_delta_widget_short;
+        }
+        if (ratio > 2.8f) {
+            return R.layout.glucose_trend_delta_widget_long;
+        }
+        return R.layout.glucose_trend_delta_widget;
+    }
+
+    private static void updateOne(AppWidgetManager mgr, int appWidgetId) {
+        try {
+            strGlucose glu;
+            notGlucose ng = SuperGattCallback.previousglucose;
+            if (ng == null) {
+                glu = Natives.lastglucose();
+                if (glu != null) {
+                    ng = new notGlucose(glu.time * 1000L, glu.value, glu.rate, glu.sensorgen2);
+                    SuperGattCallback.previousglucose = ng;
+                }
+            }
+
+            final int layout = getLayout(mgr, appWidgetId);
+            RemoteViews views = new RemoteViews(Applic.app.getPackageName(), layout);
+
+            if (ng == null) {
+                views.setTextViewText(R.id.gtdw_glucose, "- -");
+                views.setTextColor(R.id.gtdw_glucose, Color.RED);
+                views.setViewVisibility(R.id.gtdw_arrow, View.GONE);
+                views.setTextViewText(R.id.gtdw_delta, "");
+                Intent noDataIntent = new Intent(Applic.app, MainActivity.class);
+                PendingIntent noDataPi = PendingIntent.getActivity(
+                        Applic.app, 0, noDataIntent, PendingIntent.FLAG_UPDATE_CURRENT | penmutable);
+                views.setOnClickPendingIntent(R.id.glucose_trend_delta_widget_root, noDataPi);
+                mgr.updateAppWidget(appWidgetId, views);
+                return;
+            }
+
+            final boolean stale = (System.currentTimeMillis() - ng.time) > glucosetimeout;
+            final int valueColor = stale
+                    ? Color.GRAY
+                    : RemoteGlucose.glucoseRangeColor(SuperGattCallback.previousglucosevalue);
+
+            // Background tint (0 = transparent by default)
+            final int bgAlpha = RemoteGlucose.getWidgetBgAlpha();
+            if (bgAlpha > 0) {
+                views.setInt(R.id.glucose_trend_delta_widget_root, "setBackgroundColor",
+                        Color.argb(bgAlpha, 0, 0, 0));
+            } else {
+                views.setInt(R.id.glucose_trend_delta_widget_root, "setBackgroundColor",
+                        Color.TRANSPARENT);
+            }
+
+            // Glucose value
+            views.setTextViewText(R.id.gtdw_glucose, ng.value);
+            views.setTextColor(R.id.gtdw_glucose, valueColor);
+            if (stale) {
+                views.setInt(R.id.gtdw_glucose, "setPaintFlags",
+                        android.graphics.Paint.STRIKE_THRU_TEXT_FLAG);
+            } else {
+                views.setInt(R.id.gtdw_glucose, "setPaintFlags", 0);
+            }
+
+            // Trend arrow
+            final float rate = ng.rate;
+            if (!Float.isNaN(rate)) {
+                views.setImageViewBitmap(R.id.gtdw_arrow, buildArrowBitmap(rate, valueColor));
+                views.setViewVisibility(R.id.gtdw_arrow, View.VISIBLE);
+            } else {
+                views.setViewVisibility(R.id.gtdw_arrow, View.GONE);
+            }
+
+            // Delta
+            final float delta5 = ng.rate * 5f;
+            final String deltaStr = Float.isNaN(delta5) ? "\u0394 --"
+                    : "\u0394 " + String.format(Applic.usedlocale,
+                          Applic.unit == 1 ? "%+.1f" : "%+.0f", delta5);
+            views.setTextViewText(R.id.gtdw_delta, deltaStr);
+            views.setTextColor(R.id.gtdw_delta, valueColor);
+
+            // Tap opens app
+            Intent intent = new Intent(Applic.app, MainActivity.class);
+            PendingIntent pi = PendingIntent.getActivity(
+                    Applic.app, 0, intent, PendingIntent.FLAG_UPDATE_CURRENT | penmutable);
+            views.setOnClickPendingIntent(R.id.glucose_trend_delta_widget_root, pi);
+
+            mgr.updateAppWidget(appWidgetId, views);
+        } catch (Throwable th) {
+            Log.stack(LOG_ID, "updateOne", th);
+        }
+    }
+
+    private static Bitmap buildArrowBitmap(float rate, int color) {
+        final int size = 128;
+        final Bitmap bmp = Bitmap.createBitmap(size, size, Bitmap.Config.ARGB_8888);
+        final Canvas cv = new Canvas(bmp);
+        cv.drawColor(Color.TRANSPARENT, PorterDuff.Mode.CLEAR);
+        final Paint p = new Paint();
+        p.setAntiAlias(true);
+        p.setColor(color);
+        p.setStrokeWidth(4f);
+        final float density = size / 54f;
+        final float cx = size * 0.65f;
+        final float cy = size * 0.50f;
+        CommonCanvas.drawarrow(cv, p, density, rate, cx, cy);
+        return bmp;
+    }
+
+    private static void updateAll(AppWidgetManager mgr, int[] ids) {
+        if (ids == null || ids.length == 0) return;
+        used = true;
+        for (int id : ids) updateOne(mgr, id);
+    }
+
+    @Override
+    public void onUpdate(Context ctx, AppWidgetManager mgr, int[] ids) {
+        {if(doLog) {Log.i(LOG_ID, "onUpdate");};};
+        updateAll(mgr, ids);
+    }
+
+    @Override
+    public void onAppWidgetOptionsChanged(Context ctx, AppWidgetManager mgr, int id, Bundle opts) {
+        {if(doLog) {Log.i(LOG_ID, "onAppWidgetOptionsChanged");};};
+        used = true;
+        updateOne(mgr, id);
+    }
+
+    @Override
+    public void onEnabled(Context ctx) {
+        used = true;
+        registerTickReceiver(ctx);
+    }
+
+    @Override
+    public void onDisabled(Context ctx) {
+        used = false;
+        unregisterTickReceiver(ctx);
+    }
+
+    private static void registerTickReceiver(Context ctx) {
+        if (tickReceiver != null) return;
+        tickReceiver = new BroadcastReceiver() {
+            @Override public void onReceive(Context c, Intent i) { update(); }
+        };
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            ctx.getApplicationContext().registerReceiver(tickReceiver,
+                    new IntentFilter(Intent.ACTION_TIME_TICK),
+                    Context.RECEIVER_NOT_EXPORTED);
+        } else {
+            ctx.getApplicationContext().registerReceiver(tickReceiver,
+                    new IntentFilter(Intent.ACTION_TIME_TICK));
+        }
+    }
+
+    private static void unregisterTickReceiver(Context ctx) {
+        if (tickReceiver == null) return;
+        try { ctx.getApplicationContext().unregisterReceiver(tickReceiver); }
+        catch (Throwable ignored) {}
+        tickReceiver = null;
+    }
+
+    public static void update() {
+        if (!used) return;
+        final var mgr = AppWidgetManager.getInstance(Applic.app);
+        final int[] ids = mgr.getAppWidgetIds(
+                new ComponentName(Applic.app, GlucoseTrendDeltaWidget.class));
+        if (ids.length > 0) {
+            updateAll(mgr, ids);
+        } else {
+            used = false;
+        }
+    }
+}

--- a/Common/src/mobile/java/tk/glucodata/GlucoseTrendWidget.java
+++ b/Common/src/mobile/java/tk/glucodata/GlucoseTrendWidget.java
@@ -1,0 +1,219 @@
+/*      This file is part of Juggluco, an Android app to receive and display         */
+/*      glucose values from Freestyle Libre 2 and 3 sensors.                         */
+/*                                                                                   */
+/*      Copyright (C) 2021 Jaap Korthals Altes <jaapkorthalsaltes@gmail.com>         */
+/*                                                                                   */
+/*      Juggluco is free software: you can redistribute it and/or modify             */
+/*      it under the terms of the GNU General Public License as published            */
+/*      by the Free Software Foundation, either version 3 of the License, or         */
+/*      (at your option) any later version.                                          */
+/*                                                                                   */
+/*      Juggluco is distributed in the hope that it will be useful, but              */
+/*      WITHOUT ANY WARRANTY; without even the implied warranty of                   */
+/*      MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.                         */
+/*      See the GNU General Public License for more details.                         */
+/*                                                                                   */
+/*      You should have received a copy of the GNU General Public License            */
+/*      along with Juggluco. If not, see <https://www.gnu.org/licenses/>.            */
+
+package tk.glucodata;
+
+import static tk.glucodata.Log.doLog;
+import static tk.glucodata.Notify.glucosetimeout;
+import static tk.glucodata.Notify.penmutable;
+
+import android.app.PendingIntent;
+import android.appwidget.AppWidgetManager;
+import android.appwidget.AppWidgetProvider;
+import android.content.BroadcastReceiver;
+import android.content.ComponentName;
+import android.content.Context;
+import android.content.Intent;
+import android.content.IntentFilter;
+import android.graphics.Bitmap;
+import android.graphics.Canvas;
+import android.graphics.Color;
+import android.graphics.Paint;
+import android.graphics.PorterDuff;
+import android.os.Build;
+import android.os.Bundle;
+import android.view.View;
+import android.widget.RemoteViews;
+
+/**
+ * Home-screen widget showing glucose value (auto-sized, range-coloured) and a trend arrow.
+ * Equivalent to GDH's GlucoseTrendWidget.
+ */
+public class GlucoseTrendWidget extends AppWidgetProvider {
+
+    private static final String LOG_ID = "GlucoseTrendWidget";
+    static boolean used = true;
+
+    /** Receives ACTION_TIME_TICK to refresh the widget display every minute. */
+    private static BroadcastReceiver tickReceiver = null;
+
+    private static int getLayout(AppWidgetManager mgr, int appWidgetId) {
+        final Bundle options = mgr.getAppWidgetOptions(appWidgetId);
+        final int minWidth = options.getInt(AppWidgetManager.OPTION_APPWIDGET_MIN_WIDTH);
+        final int maxHeight = options.getInt(AppWidgetManager.OPTION_APPWIDGET_MAX_HEIGHT);
+        final float ratio = maxHeight > 0 ? (minWidth / (float) maxHeight) : Float.MAX_VALUE;
+        if (minWidth <= 110 || ratio < 0.5f) {
+            return R.layout.glucose_trend_widget_short;
+        }
+        if (ratio > 2.8f) {
+            return R.layout.glucose_trend_widget_long;
+        }
+        return R.layout.glucose_trend_widget;
+    }
+
+    private static void updateOne(AppWidgetManager mgr, int appWidgetId) {
+        try {
+            strGlucose glu;
+            notGlucose ng = SuperGattCallback.previousglucose;
+            if (ng == null) {
+                glu = Natives.lastglucose();
+                if (glu != null) {
+                    ng = new notGlucose(glu.time * 1000L, glu.value, glu.rate, glu.sensorgen2);
+                    SuperGattCallback.previousglucose = ng;
+                }
+            }
+
+            final int layout = getLayout(mgr, appWidgetId);
+            RemoteViews views = new RemoteViews(Applic.app.getPackageName(), layout);
+
+            if (ng == null) {
+                views.setTextViewText(R.id.gtw_glucose, "- -");
+                views.setTextColor(R.id.gtw_glucose, Color.RED);
+                views.setViewVisibility(R.id.gtw_arrow, View.GONE);
+                Intent noDataIntent = new Intent(Applic.app, MainActivity.class);
+                PendingIntent noDataPi = PendingIntent.getActivity(
+                        Applic.app, 0, noDataIntent, PendingIntent.FLAG_UPDATE_CURRENT | penmutable);
+                views.setOnClickPendingIntent(R.id.glucose_trend_widget_root, noDataPi);
+                mgr.updateAppWidget(appWidgetId, views);
+                return;
+            }
+
+            final boolean stale = (System.currentTimeMillis() - ng.time) > glucosetimeout;
+            final int valueColor = stale
+                    ? Color.GRAY
+                    : RemoteGlucose.glucoseRangeColor(SuperGattCallback.previousglucosevalue);
+
+            // Background tint (0 = transparent by default)
+            final int bgAlpha = RemoteGlucose.getWidgetBgAlpha();
+            if (bgAlpha > 0) {
+                views.setInt(R.id.glucose_trend_widget_root, "setBackgroundColor",
+                        Color.argb(bgAlpha, 0, 0, 0));
+            } else {
+                views.setInt(R.id.glucose_trend_widget_root, "setBackgroundColor",
+                        Color.TRANSPARENT);
+            }
+
+            views.setTextViewText(R.id.gtw_glucose, ng.value);
+            views.setTextColor(R.id.gtw_glucose, valueColor);
+            if (stale) {
+                views.setInt(R.id.gtw_glucose, "setPaintFlags",
+                        android.graphics.Paint.STRIKE_THRU_TEXT_FLAG);
+            } else {
+                views.setInt(R.id.gtw_glucose, "setPaintFlags", 0);
+            }
+
+            final float rate = ng.rate;
+            if (!Float.isNaN(rate)) {
+                views.setImageViewBitmap(R.id.gtw_arrow, buildArrowBitmap(rate, valueColor));
+                views.setViewVisibility(R.id.gtw_arrow, View.VISIBLE);
+            } else {
+                views.setViewVisibility(R.id.gtw_arrow, View.GONE);
+            }
+
+            Intent intent = new Intent(Applic.app, MainActivity.class);
+            PendingIntent pi = PendingIntent.getActivity(
+                    Applic.app, 0, intent, PendingIntent.FLAG_UPDATE_CURRENT | penmutable);
+            views.setOnClickPendingIntent(R.id.glucose_trend_widget_root, pi);
+
+            mgr.updateAppWidget(appWidgetId, views);
+        } catch (Throwable th) {
+            Log.stack(LOG_ID, "updateOne", th);
+        }
+    }
+
+    private static Bitmap buildArrowBitmap(float rate, int color) {
+        final int size = 128;
+        final Bitmap bmp = Bitmap.createBitmap(size, size, Bitmap.Config.ARGB_8888);
+        final Canvas cv = new Canvas(bmp);
+        cv.drawColor(Color.TRANSPARENT, PorterDuff.Mode.CLEAR);
+        final Paint p = new Paint();
+        p.setAntiAlias(true);
+        p.setColor(color);
+        p.setStrokeWidth(4f);
+        final float density = size / 54f;
+        final float cx = size * 0.65f;
+        final float cy = size * 0.50f;
+        CommonCanvas.drawarrow(cv, p, density, rate, cx, cy);
+        return bmp;
+    }
+
+    private static void updateAll(AppWidgetManager mgr, int[] ids) {
+        if (ids == null || ids.length == 0) return;
+        used = true;
+        for (int id : ids) updateOne(mgr, id);
+    }
+
+    @Override
+    public void onUpdate(Context ctx, AppWidgetManager mgr, int[] ids) {
+        {if(doLog) {Log.i(LOG_ID, "onUpdate");};};
+        updateAll(mgr, ids);
+    }
+
+    @Override
+    public void onAppWidgetOptionsChanged(Context ctx, AppWidgetManager mgr, int id, Bundle opts) {
+        {if(doLog) {Log.i(LOG_ID, "onAppWidgetOptionsChanged");};};
+        used = true;
+        updateOne(mgr, id);
+    }
+
+    @Override
+    public void onEnabled(Context ctx) {
+        used = true;
+        registerTickReceiver(ctx);
+    }
+
+    @Override
+    public void onDisabled(Context ctx) {
+        used = false;
+        unregisterTickReceiver(ctx);
+    }
+
+    private static void registerTickReceiver(Context ctx) {
+        if (tickReceiver != null) return;
+        tickReceiver = new BroadcastReceiver() {
+            @Override public void onReceive(Context c, Intent i) { update(); }
+        };
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            ctx.getApplicationContext().registerReceiver(tickReceiver,
+                    new IntentFilter(Intent.ACTION_TIME_TICK),
+                    Context.RECEIVER_NOT_EXPORTED);
+        } else {
+            ctx.getApplicationContext().registerReceiver(tickReceiver,
+                    new IntentFilter(Intent.ACTION_TIME_TICK));
+        }
+    }
+
+    private static void unregisterTickReceiver(Context ctx) {
+        if (tickReceiver == null) return;
+        try { ctx.getApplicationContext().unregisterReceiver(tickReceiver); }
+        catch (Throwable ignored) {}
+        tickReceiver = null;
+    }
+
+    public static void update() {
+        if (!used) return;
+        final var mgr = AppWidgetManager.getInstance(Applic.app);
+        final int[] ids = mgr.getAppWidgetIds(
+                new ComponentName(Applic.app, GlucoseTrendWidget.class));
+        if (ids.length > 0) {
+            updateAll(mgr, ids);
+        } else {
+            used = false;
+        }
+    }
+}

--- a/Common/src/mobile/java/tk/glucodata/GlucoseWidget.java
+++ b/Common/src/mobile/java/tk/glucodata/GlucoseWidget.java
@@ -101,17 +101,19 @@ static private void updateAppWidget(Context context, AppWidgetManager appWidgetM
       final var now=System.currentTimeMillis();
       final var time=SuperGattCallback.previousglucose.time;
       if((now-time)>oldage) {
-         final String tformat= timef.format(time);
-         String message = "\n  "+context.getString(R.string.nonewvalue) + tformat;
-         views=remoteMessage(message);
-         id=R.id.content;
+         // Stale: show last value with a strikethrough instead of a plain text message
+         views = remote.staleRemote(SuperGattCallback.previousglucose);
+         // id stays R.id.arrowandvalue — tap still opens the app
       }
       else {
          views = remote.arrowremote(50,SuperGattCallback.previousglucose,false);
          }
       }
    else {
-         views=remoteMessage("\n  "+context.getString(R.string.novalue));
+         RemoteViews noDataViews = new RemoteViews(Applic.app.getPackageName(), R.layout.text);
+         noDataViews.setTextColor(R.id.content, android.graphics.Color.RED);
+         noDataViews.setTextViewText(R.id.content, "\n  - -");
+         views = noDataViews;
          id=R.id.content;
          }
 
@@ -154,11 +156,20 @@ public static void oldvalue(long time) {
    int ids[] = manage.getAppWidgetIds(new ComponentName(Applic.app, cl));
    if(ids.length>0) {
       {if(doLog) {Log.i(LOG_ID,"oldvalue widgets");};};
-      final String tformat= timef.format(time);
-      String message = Applic.getContext().getString(R.string.nonewvalue) + tformat;
-      var views=remoteMessage(message);
-      for(var id:ids) {
-         showviews(views,R.id.content,manage,id);
+      // Use strikethrough rendering for stale state
+      if(remote != null && SuperGattCallback.previousglucose != null) {
+         var views = remote.staleRemote(SuperGattCallback.previousglucose);
+         for(var id:ids) {
+            showviews(views, R.id.arrowandvalue, manage, id);
+            }
+         }
+      else {
+         final String tformat= timef.format(time);
+         String message = Applic.getContext().getString(R.string.nonewvalue) + tformat;
+         var views=remoteMessage(message);
+         for(var id:ids) {
+            showviews(views,R.id.content,manage,id);
+            }
          }
       }
    else {
@@ -177,6 +188,15 @@ public static void oldvalue(long time) {
       else
          used=false;
       }
+    // Update all additional widgets
+    GlucoseTrendWidget.update();
+    GlucoseTrendDeltaWidget.update();
+    GlucoseDeltaTimeWidget.update();
+    ChartGlucoseWidget.update();
+    // Push latest reading to lock-screen wallpaper (no-op when disabled)
+    LockScreenWallpaper.update();
+    // Update persistent lock-screen glucose notification (no-op when disabled)
+    PermanentGlucoseNotification.update();
     }
 
 }

--- a/Common/src/mobile/java/tk/glucodata/LockScreenWallpaper.java
+++ b/Common/src/mobile/java/tk/glucodata/LockScreenWallpaper.java
@@ -1,0 +1,271 @@
+/*      This file is part of Juggluco, an Android app to receive and display         */
+/*      glucose values from Freestyle Libre 2 and 3 sensors.                         */
+/*                                                                                   */
+/*      Copyright (C) 2021 Jaap Korthals Altes <jaapkorthalsaltes@gmail.com>         */
+/*                                                                                   */
+/*      Juggluco is free software: you can redistribute it and/or modify             */
+/*      it under the terms of the GNU General Public License as published            */
+/*      by the Free Software Foundation, either version 3 of the License, or         */
+/*      (at your option) any later version.                                          */
+/*                                                                                   */
+/*      Juggluco is distributed in the hope that it will be useful, but              */
+/*      WITHOUT ANY WARRANTY; without even the implied warranty of                   */
+/*      MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.                         */
+/*      See the GNU General Public License for more details.                         */
+/*                                                                                   */
+/*      You should have received a copy of the GNU General Public License            */
+/*      along with Juggluco. If not, see <https://www.gnu.org/licenses/>.            */
+
+package tk.glucodata;
+
+import static tk.glucodata.Log.doLog;
+
+import android.app.WallpaperManager;
+import android.content.Context;
+import android.content.SharedPreferences;
+import android.graphics.Bitmap;
+import android.graphics.Canvas;
+import android.graphics.Color;
+import android.graphics.Paint;
+import android.graphics.PorterDuff;
+import android.os.Build;
+import android.util.DisplayMetrics;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.widget.ImageView;
+import android.widget.TextView;
+
+import java.io.IOException;
+
+/**
+ * Lock-screen overlay: renders a GDH-style card by inflating
+ * {@link R.layout#lockscreen_wallpaper_view} into an off-screen View, then
+ * measuring/drawing it to a bitmap that is placed on a full-screen transparent
+ * canvas and set as the FLAG_LOCK wallpaper layer.
+ *
+ * Card layout (inspired by GDH wallpaper.xml):
+ *   Row 1 (75 %): large glucose value (auto-sized, range-coloured)  |  trend arrow
+ *   Row 2 (25 %): 🕒 N min  |  Δ +/-value
+ *   Background   : semi-transparent dark rounded rectangle (#88000000)
+ *
+ * The bitmap outside the card is fully transparent so the user's wallpaper
+ * photo (home-screen layer managed by the launcher) shows through.
+ *
+ * On disable: WallpaperManager.clear(FLAG_LOCK) reverts to the home-screen wallpaper.
+ */
+public class LockScreenWallpaper {
+
+    private static final String LOG_ID = "LockScreenWallpaper";
+    private static final String PREFS  = "juggluco_dev";
+    private static final String KEY_WP = "lockscreen_wallpaper_enabled";
+
+    /** Vertical position of the card centre, as % of screen height (default 50%). */
+    private static final float CARD_Y_PERCENT = 0.50f;
+
+    private static boolean enabled = false;
+
+    // ── persistence ───────────────────────────────────────────────────────────
+
+    private static SharedPreferences prefs() {
+        return Applic.app.getSharedPreferences(PREFS, Context.MODE_PRIVATE);
+    }
+
+    public static boolean isEnabled() {
+        return prefs().getBoolean(KEY_WP, false);
+    }
+
+    public static void setEnabled(boolean on) {
+        if (on == enabled) return;
+        enabled = on;
+        prefs().edit().putBoolean(KEY_WP, on).apply();
+        if (on) {
+            update();
+        } else {
+            new Thread(LockScreenWallpaper::clearWallpaper).start();
+        }
+    }
+
+    public static void restoreOnBoot() {
+        enabled = isEnabled();
+        if (enabled) update();
+    }
+
+    // ── public update API ─────────────────────────────────────────────────────
+
+    public static void update() {
+        if (!enabled) return;
+        final notGlucose ng = SuperGattCallback.previousglucose;
+        if (ng == null) return;
+        new Thread(() -> applyWallpaper(ng)).start();
+    }
+
+    // ── rendering ─────────────────────────────────────────────────────────────
+
+    private static void applyWallpaper(notGlucose ng) {
+        try {
+            final WallpaperManager wm = WallpaperManager.getInstance(Applic.app);
+            final Bitmap bmp = buildBitmap(ng);
+            if (bmp == null) return;
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+                wm.setBitmap(bmp, null, false, WallpaperManager.FLAG_LOCK);
+            } else {
+                wm.setBitmap(bmp);
+            }
+            bmp.recycle();
+            if (doLog) Log.i(LOG_ID, "Lock-screen wallpaper updated: " + ng.value);
+        } catch (IOException e) {
+            Log.stack(LOG_ID, "applyWallpaper", e);
+        } catch (Throwable t) {
+            Log.stack(LOG_ID, "applyWallpaper", t);
+        }
+    }
+
+    private static void clearWallpaper() {
+        try {
+            final WallpaperManager wm = WallpaperManager.getInstance(Applic.app);
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+                wm.clear(WallpaperManager.FLAG_LOCK);
+            }
+            if (doLog) Log.i(LOG_ID, "Lock-screen wallpaper cleared.");
+        } catch (Throwable t) {
+            Log.stack(LOG_ID, "clearWallpaper", t);
+        }
+    }
+
+    /**
+     * Inflates {@link R.layout#lockscreen_wallpaper_view}, populates it with
+     * the current glucose reading, measures it, draws it to a Bitmap, then
+     * composites that Bitmap onto a full-screen transparent canvas so the card
+     * floats over the user's wallpaper photo.
+     */
+    private static Bitmap buildBitmap(notGlucose ng) {
+        try {
+            final Context ctx = Applic.app;
+            final DisplayMetrics dm = ctx.getResources().getDisplayMetrics();
+            final int screenW = dm.widthPixels;
+            final int screenH = dm.heightPixels;
+
+            // ── inflate the card layout ────────────────────────────────────────
+            final View card = LayoutInflater.from(ctx)
+                    .inflate(R.layout.lockscreen_wallpaper_view, null);
+
+            final TextView tvGlucose  = card.findViewById(R.id.lswp_glucose);
+            final ImageView ivArrow   = card.findViewById(R.id.lswp_arrow);
+            final TextView tvTime     = card.findViewById(R.id.lswp_time);
+            final TextView tvDelta    = card.findViewById(R.id.lswp_delta);
+            final ImageView ivGraph   = card.findViewById(R.id.lswp_graph);
+
+            // ── glucose value ──────────────────────────────────────────────────
+            final boolean stale =
+                    (System.currentTimeMillis() - ng.time) > Notify.glucosetimeout;
+            final int valueColor = stale
+                    ? Color.GRAY
+                    : RemoteGlucose.glucoseRangeColor(SuperGattCallback.previousglucosevalue);
+
+            tvGlucose.setText(ng.value);
+            tvGlucose.setTextColor(valueColor);
+            if (stale) {
+                tvGlucose.setPaintFlags(
+                        tvGlucose.getPaintFlags() | Paint.STRIKE_THRU_TEXT_FLAG);
+            } else {
+                tvGlucose.setPaintFlags(
+                        tvGlucose.getPaintFlags() & ~Paint.STRIKE_THRU_TEXT_FLAG);
+            }
+
+            // ── trend arrow ────────────────────────────────────────────────────
+            final float rate = ng.rate;
+            if (!Float.isNaN(rate)) {
+                ivArrow.setImageBitmap(buildArrowBitmap(rate, valueColor));
+                ivArrow.setVisibility(View.VISIBLE);
+            } else {
+                ivArrow.setVisibility(View.GONE);
+            }
+
+            // ── elapsed time ───────────────────────────────────────────────────
+            final long elapsedMin = (System.currentTimeMillis() - ng.time) / 60_000L;
+            tvTime.setText("\uD83D\uDD52 " + elapsedMin + " min");
+            tvTime.setTextColor(Color.WHITE);
+
+            // ── delta ──────────────────────────────────────────────────────────
+            final float delta5 = rate * 5f;
+            final String deltaStr;
+            if (Float.isNaN(delta5)) {
+                deltaStr = "\u0394 --";
+            } else {
+                final String fmt = Applic.unit == 1 ? "%+.1f" : "%+.0f";
+                deltaStr = "\u0394 " + String.format(Applic.usedlocale, fmt, delta5);
+            }
+            tvDelta.setText(deltaStr);
+            tvDelta.setTextColor(valueColor);
+
+            // ── graph ──────────────────────────────────────────────────────────
+            if (ivGraph != null && Applic.Nativesloaded) {
+                // Card is 500dp wide; use actual pixel width at current density.
+                // Height of the graph row is weight-2 of total card height (480dp),
+                // minus padding, minus the two text rows (~196dp combined).
+                // We use a fixed 140dp height to keep the JNI call simple.
+                final int gW = Math.round(500 * dm.density * 0.95f);
+                final int gH = Math.round(140 * dm.density);
+                if (gW >= 60 && gH >= 40) {
+                    try {
+                        final int[] pixels = Natives.getWidgetGraphBitmap(gW, gH, 3 * 3600);
+                        if (pixels != null) {
+                            final Bitmap graphBmp = Bitmap.createBitmap(
+                                    pixels, gW, gH, Bitmap.Config.ARGB_8888);
+                            ivGraph.setImageBitmap(graphBmp);
+                            ivGraph.setVisibility(View.VISIBLE);
+                        }
+                    } catch (Throwable t) {
+                        Log.stack(LOG_ID, "buildBitmap graph", t);
+                    }
+                }
+            }
+
+            // ── measure & lay out the card ────────────────────────────────────
+            // Use a fixed card width = 80% of screen width, free height
+            final int cardMaxW = (int) (screenW * 0.80f);
+            card.measure(
+                    View.MeasureSpec.makeMeasureSpec(cardMaxW, View.MeasureSpec.AT_MOST),
+                    View.MeasureSpec.makeMeasureSpec(0, View.MeasureSpec.UNSPECIFIED));
+            final int cardW = card.getMeasuredWidth();
+            final int cardH = card.getMeasuredHeight();
+            card.layout(0, 0, cardW, cardH);
+
+            // Render card to its own bitmap
+            final Bitmap cardBmp = Bitmap.createBitmap(cardW, cardH, Bitmap.Config.ARGB_8888);
+            card.draw(new Canvas(cardBmp));
+
+            // ── composite onto a full-screen transparent bitmap ────────────────
+            // Card is centred horizontally; vertical centre at CARD_Y_PERCENT.
+            final Bitmap wallpaper =
+                    Bitmap.createBitmap(screenW, screenH, Bitmap.Config.ARGB_8888);
+            final Canvas cv = new Canvas(wallpaper);
+            final float xOff = (screenW - cardW) * 0.5f;
+            final float yOff = Math.max(0f, screenH * CARD_Y_PERCENT - cardH * 0.5f);
+            cv.drawBitmap(cardBmp, xOff, yOff, new Paint(Paint.ANTI_ALIAS_FLAG));
+            cardBmp.recycle();
+
+            return wallpaper;
+        } catch (Throwable t) {
+            Log.stack(LOG_ID, "buildBitmap", t);
+            return null;
+        }
+    }
+
+    /** Creates a small transparent Bitmap with the trend arrow drawn on it. */
+    private static Bitmap buildArrowBitmap(float rate, int color) {
+        final int size = 128;
+        final Bitmap bmp = Bitmap.createBitmap(size, size, Bitmap.Config.ARGB_8888);
+        final Canvas cv  = new Canvas(bmp);
+        cv.drawColor(Color.TRANSPARENT, PorterDuff.Mode.CLEAR);
+        final Paint p = new Paint();
+        p.setAntiAlias(true);
+        p.setColor(color);
+        // density keeps the arrow proportional to GDH's 54 px baseline
+        final float density = size / 54f;
+        final float cx = size * 0.65f;
+        final float cy = size * 0.50f;
+        CommonCanvas.drawarrow(cv, p, density, rate, cx, cy);
+        return bmp;
+    }
+}

--- a/Common/src/mobile/java/tk/glucodata/PermanentGlucoseNotification.java
+++ b/Common/src/mobile/java/tk/glucodata/PermanentGlucoseNotification.java
@@ -1,0 +1,337 @@
+package tk.glucodata;
+
+import static tk.glucodata.Log.doLog;
+
+import android.app.Notification;
+import android.app.NotificationChannel;
+import android.app.NotificationManager;
+import android.content.Context;
+import android.graphics.Bitmap;
+import android.graphics.Canvas;
+import android.graphics.Color;
+import android.graphics.Paint;
+import android.graphics.PorterDuff;
+import android.graphics.drawable.Icon;
+import android.os.Build;
+import android.util.DisplayMetrics;
+import android.view.View;
+import android.widget.RemoteViews;
+
+/**
+ * Persistent, always-on glucose notification — visible whenever the lock screen is shown.
+ *
+ * Mirrors what GlucoDataHandler calls "PermanentNotification":
+ *   • Posted with VISIBILITY_PUBLIC so it shows in full on the lock screen
+ *   • setOngoing(true) + FLAG_NO_CLEAR — cannot be dismissed by the user
+ *   • Low-importance channel (no sound, no heads-up) — purely informational
+ *   • Updated on every new reading via update()
+ *
+ * Content: glucose value (large, range-coloured) | trend arrow bitmap | Δ delta | elapsed time
+ *
+ * v7 — foreground service notification: posted via startForeground() so Android cannot
+ *       collapse/group it into the lock-screen icon pill regardless of how many other
+ *       notifications are pending.
+ *
+ * Enabled/disabled via SharedPreferences key "permanent_glucose_notification" in "juggluco_dev".
+ * Default: enabled.
+ */
+public class PermanentGlucoseNotification {
+
+    private static final String LOG_ID = "PermanentGlucoseNotif";
+
+    // Notification channel for this permanent notification.
+    // Channel ID "glucosePermanent2" supersedes "glucosePermanent" (existing channels
+    // cannot have their importance changed at runtime; a new ID forces recreation).
+    static final String CHANNEL_ID   = "glucosePermanent2";
+    static final int    NOTIF_ID     = 81435;   // well away from other IDs in Notify.java
+
+    private static final String PREFS        = "juggluco_dev";
+    private static final String KEY_ENABLED  = "permanent_glucose_notification";
+
+    // ── Preference helpers ────────────────────────────────────────────────────
+
+    public static boolean isEnabled() {
+        return Applic.app
+                .getSharedPreferences(PREFS, Context.MODE_PRIVATE)
+                .getBoolean(KEY_ENABLED, true);   // default ON
+    }
+
+    public static void setEnabled(boolean enabled) {
+        Applic.app
+                .getSharedPreferences(PREFS, Context.MODE_PRIVATE)
+                .edit().putBoolean(KEY_ENABLED, enabled).apply();
+        if (enabled) {
+            update();
+        } else {
+            cancel();
+        }
+    }
+
+    // ── Lifecycle ─────────────────────────────────────────────────────────────
+
+    /** Called from keeprunning.onStartCommand() — creates channel and shows first notification. */
+    public static void init(Context context) {
+        createChannel(context);
+        if (isEnabled()) {
+            update();
+        }
+    }
+
+    /** Cancel the notification (called when user disables, or on service stop). */
+    public static void cancel() {
+        try {
+            // If this notification was promoted to the foreground service slot, we must
+            // hand the foreground badge back to Notify before cancelling, otherwise the
+            // service would be silently demoted to background.
+            if (keeprunning.theservice != null) {
+                // Restore Notify's foreground notification, then cancel our slot.
+                Notify.foregroundnot(keeprunning.theservice);
+            }
+            NotificationManager nm = (NotificationManager)
+                    Applic.app.getSystemService(Context.NOTIFICATION_SERVICE);
+            if (nm != null) nm.cancel(NOTIF_ID);
+        } catch (Throwable t) {
+            Log.stack(LOG_ID, "cancel", t);
+        }
+    }
+
+    // ── Channel creation ──────────────────────────────────────────────────────
+
+    private static void createChannel(Context context) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            NotificationManager nm = (NotificationManager)
+                    context.getSystemService(Context.NOTIFICATION_SERVICE);
+            if (nm == null) return;
+            if (nm.getNotificationChannel(CHANNEL_ID) != null) return; // already created
+
+            NotificationChannel ch = new NotificationChannel(
+                    CHANNEL_ID,
+                    context.getString(R.string.permanent_notif_channel_name),
+                    NotificationManager.IMPORTANCE_DEFAULT);  // shows as card; sound suppressed via setSound(null)
+            ch.setDescription(context.getString(R.string.permanent_notif_channel_desc));
+            ch.setSound(null, null);
+            ch.enableVibration(false);
+            ch.setShowBadge(false);
+            nm.createNotificationChannel(ch);
+        }
+    }
+
+    // ── Update (call on every new reading) ────────────────────────────────────
+
+    public static void update() {
+        if (!isEnabled()) return;
+        try {
+            final notGlucose glucose = SuperGattCallback.previousglucose;
+            if (glucose == null || glucose.value == null) return;
+
+            final Context ctx = Applic.app;
+
+            final Notification.Builder builder;
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+                builder = new Notification.Builder(ctx, CHANNEL_ID);
+            } else {
+                builder = new Notification.Builder(ctx);
+                builder.setPriority(Notification.PRIORITY_DEFAULT);
+            }
+
+            // Lock-screen visibility: always show full content
+            builder.setVisibility(Notification.VISIBILITY_PUBLIC);
+            builder.setOngoing(true);
+            builder.setOnlyAlertOnce(true);
+            builder.setAutoCancel(false);
+            builder.setShowWhen(true);
+            builder.setWhen(glucose.time);
+            builder.setSmallIcon(R.drawable.novalue);   // same small icon as glucose notification
+            builder.setContentIntent(Notify.mkpending());
+            builder.setCategory(Notification.CATEGORY_STATUS);
+
+            // Keep plain-text fallback content for system surfaces that ignore custom views.
+            builder.setContentTitle(buildSummaryTitle(glucose));
+
+            // Big (expanded) custom view: full card with graph.
+            // Collapsed custom view: just the row (no graph).
+            final RemoteViews collapsed = buildRemoteView(ctx, glucose, false);
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+                builder.setCustomContentView(collapsed);
+                builder.setCustomBigContentView(buildRemoteView(ctx, glucose, true));
+                // Do NOT wrap in DecoratedCustomViewStyle — that strips custom text colours in
+                // the collapsed row and adds unwanted system chrome around the custom view.
+            } else {
+                builder.setContent(collapsed);
+            }
+
+            Notification notif = builder.build();
+            notif.flags |= Notification.FLAG_NO_CLEAR | Notification.FLAG_ONGOING_EVENT;
+
+            // v7: post as a foreground-service notification so Android cannot collapse it
+            // into the lock-screen icon pill.  startForeground() with our ID moves the
+            // "protected" foreground badge to this notification; the existing Notify
+            // foreground notification (ID 81431) becomes a regular ongoing notification.
+            if (keeprunning.theservice != null) {
+                keeprunning.theservice.startForeground(NOTIF_ID, notif);
+            } else {
+                final NotificationManager nm = (NotificationManager)
+                        ctx.getSystemService(Context.NOTIFICATION_SERVICE);
+                if (nm != null) nm.notify(NOTIF_ID, notif);
+            }
+            if (doLog) Log.i(LOG_ID, "update posted: " + glucose.value);
+        } catch (Throwable t) {
+            Log.stack(LOG_ID, "update", t);
+        }
+    }
+
+    // ── Summary title (plain text, shown in grouped/collapsed rows) ───────────
+
+    /**
+     * Builds a compact plain-text summary for the notification's collapsed/grouped row:
+     *   "231 → Δ +3"  (or "231 ⚠ Δ --" when stale)
+     * Android displays this as {@code setContentTitle} when it stacks same-app notifications.
+     */
+    private static String buildSummaryTitle(notGlucose glucose) {
+        final long ageSec = (System.currentTimeMillis() - glucose.time) / 1000L;
+        final boolean stale = ageSec > Notify.glucosetimeoutSEC;
+        final StringBuilder sb = new StringBuilder();
+        sb.append(glucose.value);
+        if (!stale && !Float.isNaN(glucose.rate)) {
+            // Unicode trend arrows matching what Juggluco uses elsewhere
+            final float r = glucose.rate;
+            if      (r >  1.6f) sb.append(" ↑↑");
+            else if (r >  0.6f) sb.append(" ↑");
+            else if (r >  0.2f) sb.append(" ↗");
+            else if (r > -0.2f) sb.append(" →");
+            else if (r > -0.6f) sb.append(" ↘");
+            else if (r > -1.6f) sb.append(" ↓");
+            else                sb.append(" ↓↓");
+            // delta
+            final float delta5 = glucose.rate * 5f;
+            final String fmt = Applic.unit == 1 ? "  Δ %+.1f" : "  Δ %+.0f";
+            sb.append(String.format(Applic.usedlocale, fmt, delta5));
+        } else if (stale) {
+            sb.append("  ⚠  Δ --");
+        }
+        return sb.toString();
+    }
+
+    // ── RemoteViews builder ───────────────────────────────────────────────────
+
+    /**
+     * @param withGraph when true, renders and shows the pn_graph ImageView (big/expanded view).
+     *                  when false, hides it (collapsed/header view).
+     */
+    private static RemoteViews buildRemoteView(Context ctx, notGlucose glucose, boolean withGraph) {
+        final RemoteViews rv = new RemoteViews(ctx.getPackageName(),
+                R.layout.notification_glucose_permanent);
+
+        final long now      = System.currentTimeMillis();
+        final long ageSec   = (now - glucose.time) / 1000L;
+        final boolean stale = ageSec > Notify.glucosetimeoutSEC;
+
+        // ── Glucose value ───────────────────────────────────────────────────
+        rv.setTextViewText(R.id.pn_glucose, glucose.value);
+        final int glucoseColor = stale
+                ? Color.GRAY
+                : RemoteGlucose.glucoseRangeColor(SuperGattCallback.previousglucosevalue);
+        rv.setTextColor(R.id.pn_glucose, glucoseColor);
+
+        if (stale && Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+            // Strike through when stale
+            rv.setInt(R.id.pn_glucose, "setPaintFlags",
+                    android.graphics.Paint.STRIKE_THRU_TEXT_FLAG |
+                    android.graphics.Paint.ANTI_ALIAS_FLAG);
+        }
+
+        // ── Trend arrow ─────────────────────────────────────────────────────
+        if (stale || Float.isNaN(glucose.rate)) {
+            rv.setViewVisibility(R.id.pn_arrow, View.GONE);
+        } else {
+            rv.setViewVisibility(R.id.pn_arrow, View.VISIBLE);
+            // Render a small arrow bitmap (96×96 px)
+            final Bitmap arrowBmp = buildArrowBitmap(glucose.rate, glucoseColor);
+            if (arrowBmp != null) {
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+                    rv.setImageViewIcon(R.id.pn_arrow, Icon.createWithBitmap(arrowBmp));
+                } else {
+                    rv.setImageViewBitmap(R.id.pn_arrow, arrowBmp);
+                }
+            }
+        }
+
+        // ── Delta ───────────────────────────────────────────────────────────
+        if (!stale && !Float.isNaN(glucose.rate)) {
+            final float delta5 = glucose.rate * 5f;
+            final String fmt   = Applic.unit == 1 ? "%+.1f" : "%+.0f";
+            final String dStr  = "\u0394 " + String.format(Applic.usedlocale, fmt, delta5);
+            rv.setTextViewText(R.id.pn_delta, dStr);
+            rv.setTextColor(R.id.pn_delta, glucoseColor);
+        } else {
+            rv.setTextViewText(R.id.pn_delta, "\u0394 --");
+            rv.setTextColor(R.id.pn_delta, Color.GRAY);
+        }
+
+        // ── Elapsed time ────────────────────────────────────────────────────
+        final long elapsedMin = ageSec / 60L;
+        rv.setTextViewText(R.id.pn_time, elapsedMin + " min");
+        // Use white for time so it's legible on any background
+        final int timeColor = Notify.foregroundcolor != Color.BLACK
+                ? Notify.foregroundcolor : Color.WHITE;
+        rv.setTextColor(R.id.pn_time, timeColor);
+
+        // ── Graph (big/expanded view only) ──────────────────────────────────
+        if (withGraph && Applic.Nativesloaded) {
+            final Bitmap graphBmp = buildGraphBitmap(ctx);
+            if (graphBmp != null) {
+                rv.setImageViewBitmap(R.id.pn_graph, graphBmp);
+                rv.setViewVisibility(R.id.pn_graph, View.VISIBLE);
+            } else {
+                rv.setViewVisibility(R.id.pn_graph, View.GONE);
+            }
+        } else {
+            rv.setViewVisibility(R.id.pn_graph, View.GONE);
+        }
+
+        return rv;
+    }
+
+    /**
+     * Renders the 3-hour glucose history graph using the NanoVG-RT JNI backend.
+     * Width is derived from the display width; height is fixed at 100 dp.
+     */
+    private static Bitmap buildGraphBitmap(Context ctx) {
+        try {
+            final DisplayMetrics dm = ctx.getResources().getDisplayMetrics();
+            // Notification panel is full display width on most phones.
+            // Use 95% of display width to leave a small margin.
+            final int wPx = Math.round(dm.widthPixels * 0.95f);
+            // 100 dp fixed height matches the layout ImageView
+            final int hPx = Math.round(100 * dm.density);
+            if (wPx < 60 || hPx < 40) return null;
+            final int[] pixels = Natives.getWidgetGraphBitmap(wPx, hPx, 3 * 3600);
+            if (pixels == null) return null;
+            return Bitmap.createBitmap(pixels, wPx, hPx, Bitmap.Config.ARGB_8888);
+        } catch (Throwable t) {
+            Log.stack(LOG_ID, "buildGraphBitmap", t);
+            return null;
+        }
+    }
+
+    /** Renders a trend arrow bitmap (96×96 px) using the existing CommonCanvas helper. */
+    private static Bitmap buildArrowBitmap(float rate, int color) {
+        try {
+            final int sz = 96;
+            final Bitmap bmp = Bitmap.createBitmap(sz, sz, Bitmap.Config.ARGB_8888);
+            final Canvas cv  = new Canvas(bmp);
+            cv.drawColor(android.graphics.Color.TRANSPARENT, android.graphics.PorterDuff.Mode.CLEAR);
+            final Paint p = new Paint();
+            p.setAntiAlias(true);
+            p.setColor(color);
+            p.setStrokeWidth(4f);
+            // Arrow tip at (65%, 50%) — same placement as all other widget arrow bitmaps.
+            // drawarrow draws shaft backwards from the tip so this centres it in the bitmap.
+            CommonCanvas.drawarrow(cv, p, sz / 54f, rate, sz * 0.65f, sz * 0.50f);
+            return bmp;
+        } catch (Throwable t) {
+            Log.stack(LOG_ID, "buildArrowBitmap", t);
+            return null;
+        }
+    }
+}

--- a/Common/src/mobile/java/tk/glucodata/SnoozeReceiver.java
+++ b/Common/src/mobile/java/tk/glucodata/SnoozeReceiver.java
@@ -1,0 +1,63 @@
+/*      This file is part of Juggluco, an Android app to receive and display         */
+/*      glucose values from Freestyle Libre 2 and 3 sensors.                         */
+/*                                                                                   */
+/*      Copyright (C) 2021 Jaap Korthals Altes <jaapkorthalsaltes@gmail.com>         */
+/*                                                                                   */
+/*      Juggluco is free software: you can redistribute it and/or modify             */
+/*      it under the terms of the GNU General Public License as published            */
+/*      by the Free Software Foundation, either version 3 of the License, or         */
+/*      (at your option) any later version.                                          */
+/*                                                                                   */
+/*      Juggluco is distributed in the hope that it will be useful, but              */
+/*      WITHOUT ANY WARRANTY; without even the implied warranty of                   */
+/*      MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.                         */
+/*      See the GNU General Public License for more details.                         */
+/*                                                                                   */
+/*      You should have received a copy of the GNU General Public License            */
+/*      along with Juggluco. If not, see <https://www.gnu.org/licenses/>.            */
+
+package tk.glucodata;
+
+import static tk.glucodata.Log.doLog;
+
+import android.app.PendingIntent;
+import android.content.BroadcastReceiver;
+import android.content.Context;
+import android.content.Intent;
+
+/**
+ * BroadcastReceiver that handles snooze notification actions on the alarm
+ * notification.  Each action carries the snooze duration (minutes) as an
+ * intent extra.  On receipt, sets the snooze and stops the active alarm sound.
+ *
+ * Inspired by GlucoDataHandler's notification action pattern.
+ */
+public class SnoozeReceiver extends BroadcastReceiver {
+
+    static final String ACTION_SNOOZE  = "tk.glucodata.SNOOZE_ALARM";
+    static final String EXTRA_MINUTES  = "snooze_minutes";
+
+    private static final String LOG_ID = "SnoozeReceiver";
+
+    @Override
+    public void onReceive(Context context, Intent intent) {
+        Applic app = (Applic) context.getApplicationContext();
+        app.initproc();
+        if (ACTION_SNOOZE.equals(intent.getAction())) {
+            final long minutes = intent.getLongExtra(EXTRA_MINUTES, 60L);
+            {if(doLog) {Log.i(LOG_ID, "snooze " + minutes + " min from notification action");}}
+            AlarmSnooze.set(minutes);
+            Notify.stopalarm();
+        }
+    }
+
+    /** Build a PendingIntent that snoozes for {@code minutes} minutes. */
+    static PendingIntent pendingSnooze(long minutes, int requestCode) {
+        final Intent intent = new Intent(Applic.app, SnoozeReceiver.class);
+        intent.setAction(ACTION_SNOOZE);
+        intent.putExtra(EXTRA_MINUTES, minutes);
+        return PendingIntent.getBroadcast(
+                Applic.app, requestCode, intent,
+                PendingIntent.FLAG_UPDATE_CURRENT | Notify.penmutable);
+    }
+}

--- a/Common/src/mobile/res/layout/activity_alarm_lockscreen.xml
+++ b/Common/src/mobile/res/layout/activity_alarm_lockscreen.xml
@@ -1,0 +1,222 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+    Full-screen lock-screen alarm layout for Juggluco.
+    Modelled after GlucoDataHandler's activity_lockscreen.xml.
+
+    Structure:
+      · Top area  — alarm label, large glucose value + trend arrow, Δ delta, elapsed time
+      · Middle    — spacer
+      · Bottom    — Hold-to-dismiss button + Snooze-reveal button
+                    Snooze duration panel (hidden until "Snooze" is tapped):
+                    up to 3 configurable snooze buttons
+-->
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/alarm_lockscreen_root"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical"
+    android:gravity="center_horizontal"
+    android:background="#CC121212"
+    android:padding="20dp">
+
+    <!-- ── top data area ─────────────────────────────────────────────────── -->
+
+    <!-- Alarm type label  e.g. "⚠ HIGH" -->
+    <TextView
+        android:id="@+id/lockscreen_alarm_label"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="40dp"
+        android:textSize="22sp"
+        android:textColor="#FFFFFF"
+        android:textStyle="bold"
+        android:text="⚠ Alarm" />
+
+    <!-- Glucose value + trend arrow on the same row -->
+    <LinearLayout
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        android:gravity="center_vertical"
+        android:layout_marginTop="12dp">
+
+        <!-- Large glucose value, range-coloured -->
+        <TextView
+            android:id="@+id/lockscreen_glucose_value"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:textSize="80sp"
+            android:textStyle="bold"
+            android:textColor="#FFFFFF"
+            android:text="---" />
+
+        <!-- Trend arrow — Unicode character, same colour as glucose value -->
+        <TextView
+            android:id="@+id/lockscreen_trend_arrow"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="8dp"
+            android:textSize="48sp"
+            android:textColor="#FFFFFF"
+            android:text="→" />
+
+    </LinearLayout>
+
+    <!-- Δ delta — same colour as glucose value -->
+    <TextView
+        android:id="@+id/lockscreen_delta"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="6dp"
+        android:textSize="28sp"
+        android:textStyle="bold"
+        android:textColor="#DDDDDD"
+        android:text="\u0394 --" />
+
+    <!-- Elapsed time — always bright/white and bold -->
+    <TextView
+        android:id="@+id/lockscreen_time"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="4dp"
+        android:textSize="22sp"
+        android:textStyle="bold"
+        android:textColor="#FFFFFF"
+        android:text="🕒 0 min" />
+
+    <!-- Active-snooze status line (hidden unless snooze is running) -->
+    <TextView
+        android:id="@+id/lockscreen_snooze_status"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="8dp"
+        android:textSize="16sp"
+        android:textColor="#80CCFF"
+        android:visibility="gone"
+        android:text="Snoozed until --:--" />
+
+    <!-- ── 3-hour glucose history graph ────────────────────────────────── -->
+    <ImageView
+        android:id="@+id/lockscreen_graph"
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:layout_weight="1"
+        android:layout_marginTop="12dp"
+        android:scaleType="fitXY"
+        android:visibility="gone" />
+
+
+    <!-- ── snooze duration panel (hidden; revealed by btnSnoozeReveal) ───── -->
+    <LinearLayout
+        android:id="@+id/lockscreen_snooze_layout"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+        android:gravity="center"
+        android:visibility="gone"
+        android:layout_marginBottom="8dp">
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:textSize="16sp"
+            android:textColor="#CCCCCC"
+            android:layout_marginBottom="8dp"
+            android:text="@string/lockscreen_snooze" />
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal"
+            android:gravity="center">
+
+            <!-- Up to 3 snooze buttons — each takes an equal share of the full width
+                 so the label (e.g. "120 min") never overflows or gets clipped. -->
+            <Button
+                android:id="@+id/lockscreen_snooze_btn1"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:backgroundTint="#005CCC"
+                android:textColor="#FFFFFF"
+                android:textSize="14sp"
+                android:paddingStart="4dp"
+                android:paddingEnd="4dp"
+                android:visibility="gone"
+                android:layout_marginEnd="8dp" />
+
+            <Button
+                android:id="@+id/lockscreen_snooze_btn2"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:backgroundTint="#005CCC"
+                android:textColor="#FFFFFF"
+                android:textSize="14sp"
+                android:paddingStart="4dp"
+                android:paddingEnd="4dp"
+                android:visibility="gone"
+                android:layout_marginEnd="8dp" />
+
+            <Button
+                android:id="@+id/lockscreen_snooze_btn3"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:backgroundTint="#005CCC"
+                android:textColor="#FFFFFF"
+                android:textSize="14sp"
+                android:paddingStart="4dp"
+                android:paddingEnd="4dp"
+                android:visibility="gone" />
+
+        </LinearLayout>
+    </LinearLayout>
+
+    <!-- ── Snooze-reveal button ───────────────────────────────────────────── -->
+    <Button
+        android:id="@+id/lockscreen_snooze_reveal_btn"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginBottom="8dp"
+        android:textSize="18sp"
+        android:text="@string/lockscreen_snooze"
+        android:backgroundTint="#CC1A237E"
+        android:textColor="#FFFFFF" />
+
+    <!-- ── Hold-to-dismiss container ─────────────────────────────────────── -->
+    <!--
+        Press-and-hold gesture: the ProgressBar grows behind the button text
+        while the user holds down. Releasing before completion cancels.
+        Implemented entirely in AlarmLockScreenActivity without 3rd-party libs.
+    -->
+    <FrameLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginBottom="32dp">
+
+        <!-- Progress fill — grows left-to-right as the user holds -->
+        <ProgressBar
+            android:id="@+id/lockscreen_dismiss_progress"
+            style="?android:attr/progressBarStyleHorizontal"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:progressTint="#005CCC"
+            android:progressBackgroundTint="#00000000"
+            android:max="100"
+            android:progress="0" />
+
+        <!-- The button itself, transparent background so progress shows through -->
+        <Button
+            android:id="@+id/lockscreen_dismiss_btn"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:textSize="20sp"
+            android:textStyle="bold"
+            android:text="@string/lockscreen_dismiss"
+            android:backgroundTint="#CC003388"
+            android:textColor="#FFFFFF" />
+
+    </FrameLayout>
+
+</LinearLayout>

--- a/Common/src/mobile/res/values/strings.xml
+++ b/Common/src/mobile/res/values/strings.xml
@@ -1,4 +1,15 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_widget_description">Glucose widget</string>
+    <string name="widget_glucose">Glucose</string>
+    <string name="widget_glucose_trend">Glucose + Trend</string>
+    <string name="widget_glucose_trend_delta">Glucose + Trend + Delta</string>
+    <string name="widget_glucose_trend_delta_time">Glucose + Trend + Delta + Time</string>
+    <string name="widget_glucose_chart">Glucose Chart</string>
+    <string name="lockscreen_dismiss">Dismiss alarm</string>
+    <!-- Hold-to-dismiss button label (replaces simple tap dismiss) -->
+    <string name="lockscreen_dismiss_hold">Hold to dismiss</string>
+    <string name="lockscreen_snooze">Snooze</string>
+    <string name="lockscreen_snooze_for">Snooze for:</string>
+    <string name="lockscreen_snoozed_until">Snoozed until</string>
 </resources>

--- a/Common/src/mobile/res/xml/chart_glucose_widget_info.xml
+++ b/Common/src/mobile/res/xml/chart_glucose_widget_info.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Widget info for ChartGlucoseWidget: shows glucose value, trend arrow, delta, time, and 3-hour history graph -->
+<appwidget-provider xmlns:android="http://schemas.android.com/apk/res/android"
+    android:description="@string/app_widget_description"
+    android:initialKeyguardLayout="@layout/chart_glucose_widget"
+    android:initialLayout="@layout/chart_glucose_widget"
+    android:minWidth="100dp"
+    android:minHeight="150dp"
+    android:minResizeWidth="60dp"
+    android:minResizeHeight="80dp"
+    android:previewImage="@drawable/widget"
+    android:resizeMode="horizontal|vertical"
+    android:targetCellWidth="2"
+    android:targetCellHeight="3"
+    android:updatePeriodMillis="200000"
+    android:widgetCategory="home_screen" />

--- a/Common/src/mobile/res/xml/glucose_delta_time_widget_info.xml
+++ b/Common/src/mobile/res/xml/glucose_delta_time_widget_info.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Widget info for GlucoseDeltaTimeWidget: shows glucose value, Δ delta, and elapsed time -->
+<appwidget-provider xmlns:android="http://schemas.android.com/apk/res/android"
+    android:description="@string/app_widget_description"
+    android:initialKeyguardLayout="@layout/glucose_delta_widget"
+    android:initialLayout="@layout/glucose_delta_widget"
+    android:minWidth="100dp"
+    android:minHeight="100dp"
+    android:minResizeWidth="60dp"
+    android:minResizeHeight="60dp"
+    android:previewImage="@drawable/widget"
+    android:resizeMode="horizontal|vertical"
+    android:targetCellWidth="2"
+    android:targetCellHeight="2"
+    android:updatePeriodMillis="200000"
+    android:widgetCategory="home_screen" />

--- a/Common/src/mobile/res/xml/glucose_trend_delta_widget_info.xml
+++ b/Common/src/mobile/res/xml/glucose_trend_delta_widget_info.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Widget info for GlucoseTrendDeltaWidget: shows glucose value, trend arrow, and Δ delta -->
+<appwidget-provider xmlns:android="http://schemas.android.com/apk/res/android"
+    android:description="@string/app_widget_description"
+    android:initialKeyguardLayout="@layout/glucose_trend_delta_widget"
+    android:initialLayout="@layout/glucose_trend_delta_widget"
+    android:minWidth="100dp"
+    android:minHeight="80dp"
+    android:minResizeWidth="60dp"
+    android:minResizeHeight="60dp"
+    android:previewImage="@drawable/widget"
+    android:resizeMode="horizontal|vertical"
+    android:targetCellWidth="2"
+    android:targetCellHeight="2"
+    android:updatePeriodMillis="200000"
+    android:widgetCategory="home_screen" />

--- a/Common/src/mobile/res/xml/glucose_trend_widget_info.xml
+++ b/Common/src/mobile/res/xml/glucose_trend_widget_info.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Widget info for GlucoseTrendWidget: shows glucose value and trend arrow -->
+<appwidget-provider xmlns:android="http://schemas.android.com/apk/res/android"
+    android:description="@string/app_widget_description"
+    android:initialKeyguardLayout="@layout/glucose_trend_widget"
+    android:initialLayout="@layout/glucose_trend_widget"
+    android:minWidth="100dp"
+    android:minHeight="50dp"
+    android:minResizeWidth="60dp"
+    android:minResizeHeight="40dp"
+    android:previewImage="@drawable/widget"
+    android:resizeMode="horizontal|vertical"
+    android:targetCellWidth="2"
+    android:targetCellHeight="1"
+    android:updatePeriodMillis="200000"
+    android:widgetCategory="home_screen" />

--- a/Common/src/small/java/tk/glucodata/AlarmLockScreenActivity.java
+++ b/Common/src/small/java/tk/glucodata/AlarmLockScreenActivity.java
@@ -1,0 +1,41 @@
+/*      This file is part of Juggluco, an Android app to receive and display         */
+/*      glucose values from Freestyle Libre 2 and 3 sensors.                         */
+/*                                                                                   */
+/*      Copyright (C) 2021 Jaap Korthals Altes <jaapkorthalsaltes@gmail.com>         */
+/*                                                                                   */
+/*      Juggluco is free software: you can redistribute it and/or modify             */
+/*      it under the terms of the GNU General Public License as published            */
+/*      by the Free Software Foundation, either version 3 of the License, or         */
+/*      (at your option) any later version.                                          */
+/*                                                                                   */
+/*      Juggluco is distributed in the hope that it will be useful, but              */
+/*      WITHOUT ANY WARRANTY; without even the implied warranty of                   */
+/*      MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.                         */
+/*      See the GNU General Public License for more details.                         */
+/*                                                                                   */
+/*      You should have received a copy of the GNU General Public License            */
+/*      along with Juggluco. If not, see <https://www.gnu.org/licenses/>.            */
+
+package tk.glucodata;
+
+import android.app.Activity;
+import android.content.Context;
+
+/**
+ * Stub for the "small" (phone without BLE, no wearable) build variant.
+ * The real implementation lives in the mobile source set.
+ */
+public class AlarmLockScreenActivity extends Activity {
+
+    public static final String EXTRA_ALARM_KIND = "alarm_kind";
+
+    public static void close() {}
+
+    public static boolean isActive()             { return false; }
+    public static boolean isEnabled()            { return false; }
+    public static void    setEnabled(boolean on) {}
+
+    /** Always true on small variant — full-screen intent permission is not used here. */
+    public static boolean hasFullScreenIntentPermission()               { return true; }
+    public static void    requestFullScreenIntentPermission(Context ctx) {}
+}

--- a/Common/src/small/java/tk/glucodata/AlarmSnooze.java
+++ b/Common/src/small/java/tk/glucodata/AlarmSnooze.java
@@ -1,0 +1,10 @@
+package tk.glucodata;
+
+/** Stub for non-mobile build variants — snooze is only supported on phone. */
+public class AlarmSnooze {
+    public static void init()             {}
+    public static boolean isActive()      { return false; }
+    public static void set(long minutes)  {}
+    public static long snoozeUntilMs()    { return 0L; }
+    public static String snoozeUntilText(){ return ""; }
+}

--- a/Common/src/small/java/tk/glucodata/LockScreenWallpaper.java
+++ b/Common/src/small/java/tk/glucodata/LockScreenWallpaper.java
@@ -1,0 +1,27 @@
+/*      This file is part of Juggluco, an Android app to receive and display         */
+/*      glucose values from Freestyle Libre 2 and 3 sensors.                         */
+/*                                                                                   */
+/*      Copyright (C) 2021 Jaap Korthals Altes <jaapkorthalsaltes@gmail.com>         */
+/*                                                                                   */
+/*      Juggluco is free software: you can redistribute it and/or modify             */
+/*      it under the terms of the GNU General Public License as published            */
+/*      by the Free Software Foundation, either version 3 of the License, or         */
+/*      (at your option) any later version.                                          */
+/*                                                                                   */
+/*      Juggluco is distributed in the hope that it will be useful, but              */
+/*      WITHOUT ANY WARRANTY; without even the implied warranty of                   */
+/*      MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.                         */
+/*      See the GNU General Public License for more details.                         */
+/*                                                                                   */
+/*      You should have received a copy of the GNU General Public License            */
+/*      along with Juggluco. If not, see <https://www.gnu.org/licenses/>.            */
+
+package tk.glucodata;
+
+/** No-op stub for the small/no-wearable build variant. */
+public class LockScreenWallpaper {
+    public static boolean isEnabled()          { return false; }
+    public static void setEnabled(boolean on)  {}
+    public static void update()                {}
+    public static void restoreOnBoot()         {}
+}

--- a/Common/src/small/java/tk/glucodata/PermanentGlucoseNotification.java
+++ b/Common/src/small/java/tk/glucodata/PermanentGlucoseNotification.java
@@ -1,0 +1,9 @@
+package tk.glucodata;
+/** Small-form stub — persistent glucose notification is phone-only. */
+public class PermanentGlucoseNotification {
+    public static boolean isEnabled() { return false; }
+    public static void setEnabled(boolean e) {}
+    public static void init(android.content.Context c) {}
+    public static void cancel() {}
+    public static void update() {}
+}

--- a/Common/src/small/java/tk/glucodata/SnoozeReceiver.java
+++ b/Common/src/small/java/tk/glucodata/SnoozeReceiver.java
@@ -1,0 +1,17 @@
+package tk.glucodata;
+
+import android.app.PendingIntent;
+import android.content.BroadcastReceiver;
+import android.content.Context;
+import android.content.Intent;
+
+/** Stub for non-mobile build variants — snooze notification actions not supported here. */
+public class SnoozeReceiver extends BroadcastReceiver {
+    static final String ACTION_SNOOZE = "tk.glucodata.SNOOZE_ALARM";
+    static final String EXTRA_MINUTES = "snooze_minutes";
+
+    @Override
+    public void onReceive(Context context, Intent intent) {}
+
+    static PendingIntent pendingSnooze(long minutes, int requestCode) { return null; }
+}

--- a/Common/src/wear/java/tk/glucodata/AlarmLockScreenActivity.java
+++ b/Common/src/wear/java/tk/glucodata/AlarmLockScreenActivity.java
@@ -1,0 +1,43 @@
+/*      This file is part of Juggluco, an Android app to receive and display         */
+/*      glucose values from Freestyle Libre 2 and 3 sensors.                         */
+/*                                                                                   */
+/*      Copyright (C) 2021 Jaap Korthals Altes <jaapkorthalsaltes@gmail.com>         */
+/*                                                                                   */
+/*      Juggluco is free software: you can redistribute it and/or modify             */
+/*      it under the terms of the GNU General Public License as published            */
+/*      by the Free Software Foundation, either version 3 of the License, or         */
+/*      (at your option) any later version.                                          */
+/*                                                                                   */
+/*      Juggluco is distributed in the hope that it will be useful, but              */
+/*      WITHOUT ANY WARRANTY; without even the implied warranty of                   */
+/*      MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.                         */
+/*      See the GNU General Public License for more details.                         */
+/*                                                                                   */
+/*      You should have received a copy of the GNU General Public License            */
+/*      along with Juggluco. If not, see <https://www.gnu.org/licenses/>.            */
+
+package tk.glucodata;
+
+import android.app.Activity;
+import android.content.Context;
+
+/**
+ * Stub for non-mobile (Wear OS) build variants.
+ * The real implementation lives in the mobile source set.
+ * Notify.java references this class only inside an {@code if (!isWearable)} guard,
+ * so these methods are never actually called on a wearable.
+ */
+public class AlarmLockScreenActivity extends Activity {
+
+    public static final String EXTRA_ALARM_KIND = "alarm_kind";
+
+    public static void close() {}
+
+    public static boolean isActive()             { return false; }
+    public static boolean isEnabled()            { return false; }
+    public static void    setEnabled(boolean on) {}
+
+    /** Always true on non-mobile variants — full-screen intents are not used here. */
+    public static boolean hasFullScreenIntentPermission()               { return true; }
+    public static void    requestFullScreenIntentPermission(Context ctx) {}
+}

--- a/Common/src/wear/java/tk/glucodata/AlarmSnooze.java
+++ b/Common/src/wear/java/tk/glucodata/AlarmSnooze.java
@@ -1,0 +1,10 @@
+package tk.glucodata;
+
+/** Stub for Wear OS build variant — snooze is only supported on phone. */
+public class AlarmSnooze {
+    public static void init()             {}
+    public static boolean isActive()      { return false; }
+    public static void set(long minutes)  {}
+    public static long snoozeUntilMs()    { return 0L; }
+    public static String snoozeUntilText(){ return ""; }
+}

--- a/Common/src/wear/java/tk/glucodata/LockScreenWallpaper.java
+++ b/Common/src/wear/java/tk/glucodata/LockScreenWallpaper.java
@@ -1,0 +1,27 @@
+/*      This file is part of Juggluco, an Android app to receive and display         */
+/*      glucose values from Freestyle Libre 2 and 3 sensors.                         */
+/*                                                                                   */
+/*      Copyright (C) 2021 Jaap Korthals Altes <jaapkorthalsaltes@gmail.com>         */
+/*                                                                                   */
+/*      Juggluco is free software: you can redistribute it and/or modify             */
+/*      it under the terms of the GNU General Public License as published            */
+/*      by the Free Software Foundation, either version 3 of the License, or         */
+/*      (at your option) any later version.                                          */
+/*                                                                                   */
+/*      Juggluco is distributed in the hope that it will be useful, but              */
+/*      WITHOUT ANY WARRANTY; without even the implied warranty of                   */
+/*      MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.                         */
+/*      See the GNU General Public License for more details.                         */
+/*                                                                                   */
+/*      You should have received a copy of the GNU General Public License            */
+/*      along with Juggluco. If not, see <https://www.gnu.org/licenses/>.            */
+
+package tk.glucodata;
+
+/** No-op stub for Wear OS build variants. The real implementation is in mobile. */
+public class LockScreenWallpaper {
+    public static boolean isEnabled()          { return false; }
+    public static void setEnabled(boolean on)  {}
+    public static void update()                {}
+    public static void restoreOnBoot()         {}
+}

--- a/Common/src/wear/java/tk/glucodata/PermanentGlucoseNotification.java
+++ b/Common/src/wear/java/tk/glucodata/PermanentGlucoseNotification.java
@@ -1,0 +1,9 @@
+package tk.glucodata;
+/** Wear OS stub — persistent glucose notification is phone-only. */
+public class PermanentGlucoseNotification {
+    public static boolean isEnabled() { return false; }
+    public static void setEnabled(boolean e) {}
+    public static void init(android.content.Context c) {}
+    public static void cancel() {}
+    public static void update() {}
+}

--- a/Common/src/wear/java/tk/glucodata/SnoozeReceiver.java
+++ b/Common/src/wear/java/tk/glucodata/SnoozeReceiver.java
@@ -1,0 +1,17 @@
+package tk.glucodata;
+
+import android.app.PendingIntent;
+import android.content.BroadcastReceiver;
+import android.content.Context;
+import android.content.Intent;
+
+/** Stub for Wear OS build variant — snooze notification actions not supported on watch. */
+public class SnoozeReceiver extends BroadcastReceiver {
+    static final String ACTION_SNOOZE = "tk.glucodata.SNOOZE_ALARM";
+    static final String EXTRA_MINUTES = "snooze_minutes";
+
+    @Override
+    public void onReceive(Context context, Intent intent) {}
+
+    static PendingIntent pendingSnooze(long minutes, int requestCode) { return null; }
+}


### PR DESCRIPTION
## Overview

Phone-only features. Wear OS and small-variant source sets receive no-op stubs. No existing behaviour is changed for users who do not enable the new options.

---

## Shared visual conventions

Every new surface applies the same colour rules and staleness logic.

### Glucose value colour

Derived from the alarm and target thresholds already configured in Juggluco's alarm settings:

| Colour | Meaning | Condition |
|--------|---------|-----------|
| Green | In target range | Value is between *target low* and *target high* |
| Yellow | Warning — outside target but not yet at alarm | Value is between the target boundary and the alarm boundary |
| Red | At or beyond alarm threshold | Value <= alarm low **or** >= alarm high |
| Gray + strikethrough | Stale reading | Last reading is more than 5 min 30 s old |

If no target thresholds are set, the alarm thresholds are used as the target range (no yellow band). If no thresholds are configured at all, the value is shown in white.

### Trend arrow

Seven levels based on the rate of change (units per minute):

| Arrow | Rate |
|-------|------|
| Steep rise | > +1.6 /min |
| Rise | +0.6 to +1.6 /min |
| Slight rise | +0.2 to +0.6 /min |
| Flat | -0.2 to +0.2 /min |
| Slight fall | -0.2 to -0.6 /min |
| Fall | -0.6 to -1.6 /min |
| Steep fall | < -1.6 /min |

On widgets the arrow is drawn as a bitmap via the existing `CommonCanvas.drawarrow()` function. On the alarm activity it is a Unicode character in the same colour as the glucose value.

### Delta

Shown as **+4** (mg/dL) or **+0.2** (mmol/L). Computed as *rate x 5 minutes*. Shown as **--** when the rate is not available. Uses the same unit and locale format as the rest of the app.

### Elapsed time

Minutes since the last sensor reading. Refreshed every minute via an `ACTION_TIME_TICK` broadcast receiver.

---

## 1 · Three new home-screen widgets

Three new `AppWidgetProvider` classes alongside the existing `GlucoseWidget`:

| Widget name (picker) | Displays |
|---|---|
| **Glucose + Trend** | Large glucose value · trend arrow |
| **Glucose + Trend + Delta** | Large glucose value · trend arrow · delta |
| **Glucose + Trend + Delta + Time** | Large glucose value · trend arrow · delta · elapsed minutes |

### Responsive size variants

Each widget reads its cell size on every update and on `onAppWidgetOptionsChanged()`, picking one of three XML layouts:

- **Short** — narrow cell (<= 110 dp wide) or ratio < 0.5: compact stacking
- **Normal** — default for typical 2-column cells
- **Long** — very wide cell (ratio > 2.8): all fields on one horizontal row

New files: `GlucoseTrendWidget.java`, `GlucoseTrendDeltaWidget.java`, `GlucoseDeltaTimeWidget.java`  
New layouts: `glucose_trend_widget{,_short,_long}.xml`, `glucose_trend_delta_widget{,_short,_long}.xml`, `glucose_delta_widget{,_short,_long}.xml`  
New widget info: `glucose_trend_widget_info.xml`, `glucose_trend_delta_widget_info.xml`, `glucose_delta_time_widget_info.xml`

---

## 2 · Chart widget with 3-hour glucose history graph

The **Glucose Chart** widget (`ChartGlucoseWidget`) adds a glucose history graph rendered via `Natives.getWidgetGraphBitmap()` using the NanoVG software rendering backend already present in Juggluco.

- Top row: glucose value · arrow · elapsed time · delta
- Bottom area: 3-hour glucose curve
- Same three size variants (short hides the graph and time/delta; long splits horizontally)
- Graph is hidden gracefully when the native library is not loaded

New files: `ChartGlucoseWidget.java`, `chart_glucose_widget{,_short,_long}.xml`, `chart_glucose_widget_info.xml`  
Modified: `javacurve.cpp` (adds `getWidgetGraphBitmap()` JNI implementation), `Natives.java` (declares the native method)

---

## 3 · Persistent glucose notification always visible on the lock screen

`PermanentGlucoseNotification` keeps a notification in the shade and on the lock screen at all times while the service runs.

- **Collapsed row**: glucose value (range-coloured) · trend arrow · delta · elapsed time. A plain-text `setContentTitle()` fallback is kept for manufacturer skins that ignore custom notification layouts.
- **Expanded row**: same row + 3-hour graph below
- Posted via `startForeground(NOTIF_ID, ...)` to prevent Android collapsing it into an icon pill on the lock screen
- Channel `glucosePermanent2` — `IMPORTANCE_DEFAULT`, sound null, vibration disabled

**Enable/disable**: Settings → *Glucose on lock screen* (default: enabled)

New files: `PermanentGlucoseNotification.java`, `notification_glucose_permanent.xml`

> **Note**: on some manufacturer Android skins the system may ignore the custom notification layout and show only plain text in the collapsed row.

---

## 4 · Full-screen alarm overlay on the lock screen

`AlarmLockScreenActivity` fires as a full-screen intent when a glucose alarm triggers, waking the screen and showing a dark overlay without requiring the phone to be unlocked.

**Screen contents**:
- Alarm label (e.g. *HIGH*, *LOW*)
- Large glucose value — range-coloured, or gray with strikethrough if stale
- Trend arrow — same colour as the value
- Delta (5-minute projection)
- Elapsed time — updated every minute
- Active-snooze status line — shown only when a snooze is running
- 3-hour glucose history graph — shown when the native library is loaded

**Hold-to-dismiss**: press and hold 1.5 s — a progress bar fills while held; releasing early cancels without stopping the alarm. The alarm's re-fire interval is shown in the button label, e.g. *"Hold to dismiss (+60 min)"*.

**Snooze panel**: tapping **Snooze** reveals up to 3 duration buttons (configurable in Alarm Settings); tapping one stops the alarm and suppresses it for that period.

**Auto-dismiss**: after 5 minutes, or immediately when the alarm is cleared by any other means.

**Android 14+ permission**: `USE_FULL_SCREEN_INTENT` requires explicit user approval on API 34+. A *"Grant full-screen alarm permission"* button appears in Settings only when the permission is missing, opening the relevant system settings page directly.

**Enable/disable**: Settings → *Alarm on lock screen* (default: enabled)

New files: `AlarmLockScreenActivity.java`, `activity_alarm_lockscreen.xml`

---

## 5 · Alarm snooze — notification actions and lock-screen buttons

- **Notification action buttons**: up to 3 one-tap snooze buttons appear in the expanded alarm notification, handled by `SnoozeReceiver`
- **Lock-screen activity**: same buttons available on the full-screen alarm overlay
- Snooze state is persisted in `SharedPreferences` and survives process restarts
- **Configure durations**: Alarm Settings → *Snooze buttons* — choose up to 3 from {30, 60, 90, 120 min} (default: 60 / 90 / 120)
- **Cancel snooze**: Alarm Settings — button shows remaining time when a snooze is active, dimmed otherwise

New files: `AlarmSnooze.java`, `SnoozeReceiver.java`

---

## 6 · Lock-screen wallpaper with glucose card

`LockScreenWallpaper` replaces the Android `FLAG_LOCK` wallpaper layer with a semi-transparent glucose card centred on the screen. The user's home-screen photo remains unchanged and is visible through the transparent areas around the card.

**Card content**: glucose value (range-coloured, auto-sized) · trend arrow · elapsed time · delta · 3-hour graph (when available)  
**Card background**: `#88000000` rounded rectangle (~53 % opaque black)

- Updated on a background thread on every new sensor reading
- Restored automatically on device boot if the setting was enabled
- On disable: `WallpaperManager.clear(FLAG_LOCK)` reverts to the previous lock-screen wallpaper immediately

**Enable/disable**: Settings → *Lock screen wallpaper* (default: disabled)

New files: `LockScreenWallpaper.java`, `lockscreen_wallpaper_view.xml`, `lockscreen_wallpaper_bg.xml`

> **Note**: on Android 7 and later only the lock-screen layer is replaced — the home-screen wallpaper is unchanged. On Android 6 and earlier the system wallpaper (both layers) is replaced.

---

## 7 · Configurable widget background opacity

All four new widgets support a semi-transparent dark background to improve legibility over bright wallpapers:

| Option | Effect |
|--------|--------|
| None (transparent) | Text floats over wallpaper — default |
| Light 25 % | Faint dark background |
| Medium 50 % | Half-opaque dark background |
| Dark 75 % | High-contrast dark background |

**Settings → *Widget background***

---

## Settings screen — new controls

Two new rows inserted before the alarm/exchange section:

| Row | Controls |
|-----|---------|
| Checkboxes | *Lock screen wallpaper* · *Alarm on lock screen* · *Glucose on lock screen* |
| Buttons | *Widget background* · *Grant full-screen alarm permission* (Android 14+ only; hidden when already granted) |

Snooze controls (*Snooze buttons* picker + *Cancel snooze*) are in the Alarm Settings screen.

---

## Wear OS and small-variant stubs

No-op stubs added for all new classes in `src/wear/` and `src/small/` so all build variants compile cleanly. `AlarmLockScreenActivity` stubs include `hasFullScreenIntentPermission()` and `requestFullScreenIntentPermission()` to satisfy call sites in the `main` source set (`Notify.java`, `Settings.java`).

---

## Code cleanup

- RTL-safe `marginStart`/`End` in `glucose_delta_widget.xml` (was `marginLeft`/`Right`)
- Corrected `BroadcastReceiver` field javadoc in all three simple widget classes
- Removed inconsistent section-divider comment in `GlucoseDeltaTimeWidget`
- Simplified stale channel comment in `PermanentGlucoseNotification`

---

## Testing

1. Add each widget to the home screen; resize to narrow, normal and wide cells — confirm the correct layout variant is selected each time.
2. Verify glucose colours: in-range → green, warn zone → yellow, at alarm boundary → red.
3. Let the last reading go stale (> 5 min 30 s); confirm gray + strikethrough on all surfaces.
4. Trigger a glucose alarm; test hold-to-dismiss (release early → alarm continues; hold full → alarm stops).
5. Snooze via the lock-screen buttons and via the notification action; confirm suppression and the status line shows the end time.
6. Enable *Lock screen wallpaper*; confirm the card is visible on the lock screen and disappears on disable.
7. Enable *Glucose on lock screen*; confirm the persistent notification shows a range-coloured value in both collapsed and expanded states.
8. Android 14+: revoke `USE_FULL_SCREEN_INTENT`; confirm the permission button appears in Settings.

## AI Assistant

- IBM Bob