### PR TITLE
ssl: trust user-installed CA certificates in Java and native OpenSSL …

### DIFF
--- a/Common/src/main/cpp/net/ICE/ContextHTTPS.cpp
+++ b/Common/src/main/cpp/net/ICE/ContextHTTPS.cpp
@@ -152,6 +152,11 @@ std::string get_openssl_error_string() {
     return uit;
     }
 // Load Android system CA certs (DER format) into the given X509_STORE
+// Also loads user-installed CA certs from /data/misc/user/0/cacerts-added/
+// so that CAs installed via Settings > Security > Install certificate are trusted.
+// This is necessary because Android 7+ apps with targetSdkVersion>=24 do not
+// trust user CAs by default; the network_security_config handles the Java layer,
+// but the native OpenSSL path must load them explicitly.
 static bool load_android_cacerts(SSL_CTX* ctx) {
 #ifndef READ_CACERTS
      if(SSL_CTX_set_default_verify_paths(ctx)) {
@@ -165,16 +170,16 @@ static bool load_android_cacerts(SSL_CTX* ctx) {
         }
 #else
    constexpr const char ca_dir[] = "/system/etc/security/cacerts";
-//    constexpr const char ca_dir[] = "/data/local/tmp/cacerts";
-    if(SSL_CTX_load_verify_locations(ctx, NULL, ca_dir)) {
-        LOGARHTTPS("SSL_CTX_load_verify_locations Succeeded");
-        return true;
-        }
-     else {
+   constexpr const char user_ca_dir[] = "/data/misc/user/0/cacerts-added";
+    if(!SSL_CTX_load_verify_locations(ctx, NULL, ca_dir)) {
         std::string er=get_openssl_error_string();
-        LOGGERHTTPS("SSL_CTX_load_verify_locations failed: %s\n",er.data());
+        LOGGERHTTPS("SSL_CTX_load_verify_locations(%s) failed: %s\n",ca_dir,er.data());
         return false;
         }
+    LOGARHTTPS("SSL_CTX_load_verify_locations system Succeeded");
+    // User-installed CAs (optional — directory may not exist or be unreadable)
+    SSL_CTX_load_verify_locations(ctx, NULL, user_ca_dir);
+    return true;
 #endif
 }
 /*

--- a/Common/src/main/res/xml/network_security_config.xml
+++ b/Common/src/main/res/xml/network_security_config.xml
@@ -2,6 +2,10 @@
 
 <network-security-config>
     <base-config cleartextTrafficPermitted="true">
+        <trust-anchors>
+            <certificates src="system" />
+            <certificates src="user" />
+        </trust-anchors>
     </base-config>
 </network-security-config>
 


### PR DESCRIPTION
## Problem

Let's Encrypt started issuing certificates under the new "Root YR" hierarchy
(ISRG, issued Sep 2025). This root CA is not yet present in most Android
system trust stores. As a result, connections to servers using these
certificates fail with:

  javax.net.ssl.SSLHandshakeException: 
  CertPathValidatorException: Trust anchor for certification path not found

This affects both the Java upload layer (NightPost, Libreview) and the
native OpenSSL layer (ContextHTTPS) because Android 7+ apps with
targetSdkVersion >= 24 do not trust user-installed CAs by default.

## Solution

Allow users to install the missing root CA via
Settings > Security > Install certificate and have it trusted by all
upload paths without requiring a system update or root access.

**network_security_config.xml** — add explicit `<trust-anchors>` with
both `system` and `user` sources so that HttpURLConnection and related
Java HTTP clients honour user-installed CAs.

**ContextHTTPS.cpp** (`load_android_cacerts`) — after loading the system
CA directory (`/system/etc/security/cacerts`), also attempt to load the
user CA directory (`/data/misc/user/0/cacerts-added`). The user directory
load is best-effort: failure (directory absent or unreadable) does not
abort the connection.

## Security note

Trusting user-installed CAs is consistent with the Android security model:
the user must explicitly install the certificate via the system UI, which
requires device authentication (PIN/biometric). This is the same trust
level that browsers like Firefox use for user-added CAs.